### PR TITLE
 Removed hard dependency on matplotlib

### DIFF
--- a/wntr/graphics/color.py
+++ b/wntr/graphics/color.py
@@ -1,7 +1,8 @@
 try:
+    import matplotlib.pyplot as plt
     from matplotlib.colors import LinearSegmentedColormap
 except:
-    pass
+    plt = None
 import logging
 
 logger = logging.getLogger(__name__)
@@ -27,6 +28,9 @@ def custom_colormap(numcolors=11, colors=['blue','white','red'], name='custom'):
     --------
     cmap : matplotlib.colors.LinearSegmentedColormap object
     """
+    if plt is None:
+        raise ImportError('matplotlib is required')
+    
     cmap = LinearSegmentedColormap.from_list(name=name, 
                                              colors = colors,
                                              N=numcolors)

--- a/wntr/graphics/curve.py
+++ b/wntr/graphics/curve.py
@@ -6,7 +6,7 @@ import numpy as np
 try:
     import matplotlib.pyplot as plt
 except:
-    pass
+    plt = None
 import logging
 
 logger = logging.getLogger(__name__)
@@ -52,6 +52,9 @@ def plot_fragility_curve(FC, fill=True, key='Default',
     figsize : list (optional)
         Figure size (default = [8,4])
 """
+    if plt is None:
+        raise ImportError('matplotlib is required')
+    
     plt.figure(figsize=tuple(figsize))
     plt.title(title)
     x = np.linspace(xmin,xmax,npoints)
@@ -107,6 +110,9 @@ def plot_pump_curve(pump, title='Pump curve',
     figsize : list (optional)
         Figure size (default = [8,4])
     """
+    if plt is None:
+        raise ImportError('matplotlib is required')
+    
     plt.figure(figsize=tuple(figsize))
     plt.title(title)
     x = []

--- a/wntr/graphics/network.py
+++ b/wntr/graphics/network.py
@@ -8,11 +8,11 @@ from wntr.graphics.color import custom_colormap
 try:
     import matplotlib.pyplot as plt
 except:
-    pass
+    plt = None
 try:
     import plotly
 except:
-    pass
+    plotly = None
 import logging
 
 logger = logging.getLogger(__name__)
@@ -103,6 +103,11 @@ def plot_network(wn, node_attribute=None, link_attribute=None, title=None,
     -----
     For more network draw options, see nx.draw_networkx
     """
+    
+    if plt is None:
+        raise ImportError('matplotlib is required')
+
+
     if node_cmap is None:
         node_cmap = plt.cm.jet
     if link_cmap is None:
@@ -282,7 +287,9 @@ def plot_interactive_network(wn, node_attribute=None, title=None,
     filename : string, optional
         HTML file name (default=None, temp-plot.html)
     """
-
+    if plotly is None:
+        raise ImportError('plotly is required')
+        
     # Graph
     G = wn.get_graph_deep_copy()
     

--- a/wntr/graphics/network.py
+++ b/wntr/graphics/network.py
@@ -18,8 +18,8 @@ import logging
 logger = logging.getLogger(__name__)
 
 def plot_network(wn, node_attribute=None, link_attribute=None, title=None,
-               node_size=20, node_range = [None,None], node_cmap=plt.cm.jet, node_labels=False,
-               link_width=1, link_range = [None,None], link_cmap=plt.cm.jet, link_labels=False,
+               node_size=20, node_range = [None,None], node_cmap=None, node_labels=False,
+               link_width=1, link_range = [None,None], link_cmap=None, link_labels=False,
                add_colorbar=True, directed=False, ax=None):
     """
     Plot network graphic using networkx. 
@@ -103,7 +103,11 @@ def plot_network(wn, node_attribute=None, link_attribute=None, title=None,
     -----
     For more network draw options, see nx.draw_networkx
     """
-
+    if node_cmap is None:
+        node_cmap = plt.cm.jet
+    if link_cmap is None:
+        link_cmap = plt.cm.jet
+        
     if ax is None: # create a new figure
         plt.figure(facecolor='w', edgecolor='k')
         ax = plt.gca()


### PR DESCRIPTION
This PR removes the hard dependency on matplotlib.  Matplotlib is only required if you use functionality in wntr.graphics and if you run the tests and examples.  wntr can be imported without matplotlib installed.