### PR TITLE
Minor updates to the population metric, epanet IO, skeletonization, and examples

### DIFF
--- a/examples/resilience_metrics.py
+++ b/examples/resilience_metrics.py
@@ -283,7 +283,7 @@ def water_security_metrics(wn):
     VC = wntr.metrics.volume_contaminant_consumed(demand, quality, 0.001)
     EC = wntr.metrics.extent_contaminant(quality, flowrate, wn, 0.001)
 
-    wntr.graphics.plot_network(wn, node_attribute=MC.sum(axis=0), node_range = [0,400], node_size=40,
+    wntr.graphics.plot_network(wn, node_attribute=MC.sum(axis=0), node_range = [0,1e5], node_size=40,
                           title='Total mass consumed')
 
     plt.figure()

--- a/examples/stochastic_simulation.py
+++ b/examples/stochastic_simulation.py
@@ -83,9 +83,7 @@ for i in range(Imax):
     wn = pickle.load(f)
     f.close()
 
-### ANALYSIS ###
-nzd_junctions = [j_name for j_name, j in wn.junctions() if sum(d.base_value for d in j.demand_timeseries_list) != 0]
-
+### ANALYSIS ###  
 result_names = results.keys()
 for name in result_names:
 

--- a/examples/water_quality_simulation.py
+++ b/examples/water_quality_simulation.py
@@ -15,6 +15,7 @@ wn.add_pattern('SourcePattern', source_pattern)
 wn.add_source('Source1', '121', 'SETPOINT', 1000, 'SourcePattern')
 wn.add_source('Source2', '123', 'SETPOINT', 1000, 'SourcePattern')
 results = sim.run_sim()
+
 CHEM_at_5hr = results.node['quality'].loc[5*3600,:]
 wntr.graphics.plot_network(wn, node_attribute=CHEM_at_5hr, node_size=20, 
                       title='Chemical concentration, time = 5 hours')
@@ -54,4 +55,6 @@ sim = wntr.sim.WNTRSimulator(wn)
 results = sim.run_sim()
 wn.assign_demand(results.node['demand'], 'PDD')
 sim = wntr.sim.EpanetSimulator(wn)
+wn.options.quality.mode = 'TRACE'
+wn.options.quality.trace_node = '111'
 results_withPDdemands = sim.run_sim()

--- a/wntr/epanet/io.py
+++ b/wntr/epanet/io.py
@@ -2583,6 +2583,8 @@ class BinFile(object):
             simulation results in a different format (such as directly to a file or database).
             
         """
+        self.results = wntr.sim.SimulationResults()
+        
         logger.debug('Read binary EPANET data from %s',filename)
         dt_str = '|S{}'.format(self.idlen)
         with open(filename, 'rb') as fin:

--- a/wntr/metrics/misc.py
+++ b/wntr/metrics/misc.py
@@ -11,7 +11,7 @@ topographic, hydraulic, water quality, water security, or economic categories.
     population_impacted
 
 """
-from wntr.metrics.hydraulic import expected_demand
+from wntr.metrics.hydraulic import average_expected_demand
 import logging
 
 logger = logging.getLogger(__name__)
@@ -49,11 +49,12 @@ def population(wn, R=0.00000876157):
     """
     Compute population per node, rounded to the nearest integer [USEPA15]_.
 
-    .. math:: pop=\dfrac{expected_demand}{R}
+    .. math:: pop=\dfrac{Average\ expected\ demand}{R}
 
     Parameters
     -----------
     wn : wntr WaterNetworkModel
+        Water network model
 
     R : float (optional, default = 0.00000876157 m3/s = 200 gallons/day)
         Average volume of water consumed per capita per day in m3/s
@@ -63,8 +64,8 @@ def population(wn, R=0.00000876157):
     A pandas Series that contains population per node
     """
 
-    ex_dem = expected_demand(wn)
-    pop = ex_dem.mean(axis=0)/R
+    ave_ex_dem = average_expected_demand(wn)
+    pop = ave_ex_dem/R
 
     return pop.round()
 

--- a/wntr/morph/skel.py
+++ b/wntr/morph/skel.py
@@ -189,6 +189,7 @@ class _Skeletonize(object):
             # Move demand
             junc = self.wn.get_node(junc_name)
             for demand in junc.demand_timeseries_list:
+                demand.category = None
                 neigh_junc.demand_timeseries_list.append(demand)
             junc.demand_timeseries_list.clear()
 
@@ -261,6 +262,7 @@ class _Skeletonize(object):
             # Move demand
             junc = self.wn.get_node(junc_name)
             for demand in junc.demand_timeseries_list:
+                demand.category = None
                 closest_junc.demand_timeseries_list.append(demand)
             junc.demand_timeseries_list.clear()
 


### PR DESCRIPTION
This PR contains several updates, including:
* Updated population metric to use `average_expected_demand` (which is the average over 1 day) instead of the average of `expected_demand` (which uses the simulation start and end time as default)
* Updated BinFile.read to create a new results object each time it is called
* Renamed demand category to None when merging demands in skeletonization
* Minor updates to examples