### PR TITLE
bug in AndCondition.requires

### DIFF
--- a/wntr/network/controls.py
+++ b/wntr/network/controls.py
@@ -964,7 +964,9 @@ class OrCondition(ControlCondition):
         return np.max([self._condition_1.backtrack, self._condition_2.backtrack])
 
     def requires(self):
-        return self._condition_1.requires().update(self._condition_2.requires())
+        req = self._condition_1.requires()
+        req.update(self._condition_2.requires())
+        return req
 
 
 @DocInheritor({'requires', 'evaluate', 'backtrack'})

--- a/wntr/network/controls.py
+++ b/wntr/network/controls.py
@@ -1026,7 +1026,9 @@ class AndCondition(ControlCondition):
         return np.min([self._condition_1.backtrack, self._condition_2.backtrack])
 
     def requires(self):
-        return self._condition_1.requires().update(self._condition_2.requires())
+        req = self._condition_1.requires()
+        req.update(self._condition_2.requires())
+        return req
 
 
 class _CloseCVCondition(ControlCondition):


### PR DESCRIPTION
Addresses #79 

Note: 
The USEPA/WNTR GitHub site, https://github.com/USEPA/WNTR, does not link to Travis CI for continuous integration software testing.  
The core development team uses the sandialabs/WNTR fork, https://github.com/sandialabs/wntr, to run tests.
To submit a Pull Request to USEPA/WNTR, the developer needs to link their fork to Travis so that test results can be inspected.
If the developer does not have Travis linked to their fork, the Pull Request can be submitted to the sandialabs/WNTR fork.

