### PR TITLE
Fixed assign_demand

### DIFF
--- a/documentation/waterquality.rst
+++ b/documentation/waterquality.rst
@@ -139,7 +139,7 @@ water quality are run using the EpanetSimualtor.
     >>> sim = wntr.sim.WNTRSimulator(wn, 'PDD')
     >>> results = sim.run_sim()
 
-    >>> wn.assign_demand(results.node['demand'], 'PDD')
+    >>> wn.assign_demand(results.node['demand'].loc[:,wn.junction_name_list], 'PDD')
 	
     >>> sim = wntr.sim.EpanetSimulator(wn)
     >>> wn.options.quality.mode = 'TRACE'

--- a/documentation/whatsnew.rst
+++ b/documentation/whatsnew.rst
@@ -1,6 +1,8 @@
 Release notes
 ================
 
+.. include:: whatsnew/v0.2.2.1.rst
+
 .. include:: whatsnew/v0.2.2.rst
 
 .. include:: whatsnew/v0.2.1.rst

--- a/documentation/whatsnew/v0.2.2.1.rst
+++ b/documentation/whatsnew/v0.2.2.1.rst
@@ -1,0 +1,11 @@
+.. _whatsnew_0221:
+
+v0.2.2.1
+---------------------------------------------------
+
+* Fixed :class:`~wntr.network.model.WaterNetworkModel.assign_demand`. 
+  The function now reassigns demands using the demand_timeseries_list and uses the demand 
+  multiplier to create a new pattern.
+* Updated tests
+* Updated documentation
+  

--- a/wntr/__init__.py
+++ b/wntr/__init__.py
@@ -7,7 +7,7 @@ from wntr import scenario
 from wntr import graphics
 from wntr import utils
 
-__version__ = '0.2.2'
+__version__ = '0.2.2.1'
 
 __copyright__ = """Copyright 2019 National Technology & Engineering 
 Solutions of Sandia, LLC (NTESS). Under the terms of Contract DE-NA0003525 

--- a/wntr/network/model.py
+++ b/wntr/network/model.py
@@ -1517,40 +1517,42 @@ class WaterNetworkModel(AbstractModel):
         """
         Assign demands using values in a DataFrame. 
         
-        New demands are specified in a pandas DataFrame indexed by simulation
-        time (in seconds) and one column for each node. The method resets
-        node demands by creating a new demand pattern for each node and
-        resetting the base demand to 1. The demand pattern is resampled to
-        match the water network model pattern timestep. This method can be
+        New demands are specified in a pandas DataFrame indexed by
+        time (in seconds). The method resets junction demands by creating a 
+        new demand pattern and using a base demand of 1. 
+        The demand pattern is resampled to match the water network model 
+        pattern timestep. This method can be
         used to reset demands in a water network model to demands from a
         pressure dependent demand simulation.
 
         Parameters
         ----------
         demand : pandas DataFrame
-            A pandas DataFrame containing demands (index = time, columns = node names)
+            A pandas DataFrame containing demands (index = time, columns = junction names)
 
         pattern_prefix: string
-            Pattern name prefix, default = 'ResetDemand'.  The junction name is appended to the prefix.  
+            Pattern name prefix, default = 'ResetDemand'.  The junction name is 
+            appended to the prefix to create a new pattern name.  
             If the pattern name already exists, an error is thrown and the user 
             should use a different pattern prefix name.
         """
-        for node_name, node in self.junctions():
+        for junc_name in demand.columns:
             
             # Extract the node demand pattern and resample to match the pattern timestep
-            demand_pattern = demand.loc[:, node_name]
+            demand_pattern = demand.loc[:, junc_name]
             demand_pattern.index = pd.TimedeltaIndex(demand_pattern.index, 's')
             resample_offset = str(int(self.options.time.pattern_timestep))+'S'
             demand_pattern = demand_pattern.resample(resample_offset).mean() / self.options.hydraulic.demand_multiplier
 
             # Add the pattern
             # If the pattern name already exists, this fails 
-            pattern_name = pattern_prefix + node_name
+            pattern_name = pattern_prefix + junc_name
             self.add_pattern(pattern_name, demand_pattern.tolist())
             
             # Reset base demand
-            node.demand_timeseries_list.clear()
-            node.demand_timeseries_list.append((1.0, pattern_name))
+            junction = self.get_node(junc_name)
+            junction.demand_timeseries_list.clear()
+            junction.demand_timeseries_list.append((1.0, pattern_name))
 
     def get_links_for_node(self, node_name, flag='ALL'):
         """

--- a/wntr/tests/test_network.py
+++ b/wntr/tests/test_network.py
@@ -439,25 +439,7 @@ class TestNetworkMethods(unittest.TestCase):
         self.assertEqual(l4,['p5'])
         self.assertEqual(l5,[])
 
-#    def test_assign_demand(self):
-#        inp_file = join(ex_datadir, 'Net3.inp')
-#        wn = self.wntr.network.WaterNetworkModel(inp_file)
-#
-#        sim = self.wntr.sim.WNTRSimulator(wn)
-#        results1 = sim.run_sim()
-#
-#        demand = results1.node['demand']
-#        wn.assign_demand(demand)
-#
-#        sim = self.wntr.sim.EpanetSimulator(wn)
-#        results2 = sim.run_sim()
-#
-#        for node_name, node in self.wn.nodes():
-#            for t in self.res1.node.major_axis:
-#                self.assertAlmostEqual(results1.link.loc['flowrate', t, node_name],
-#                                       results2.link.loc['flowrate', t, node_name], 4)
-
-
+    
 epanet_unit_id = {'CFS': 0, 'GPM': 1, 'MGD': 2, 'IMGD': 3, 'AFD': 4,
                   'LPS': 5, 'LPM': 6, 'MLD': 7, 'CMH':  8, 'CMD': 9}
 
@@ -701,6 +683,49 @@ def test_describe():
                                       'Volume': 0}, 
                            'Sources': 0, 
                            'Controls': 18})
+
+def test_assign_demand():
     
+    inp_file = join(ex_datadir, 'Net3.inp')
+    wn = wntr.network.WaterNetworkModel(inp_file)
+    demands0 = wntr.metrics.expected_demand(wn)
+    
+    wn.options.hydraulic.demand_multiplier = 1.5
+    demands1 = wntr.metrics.expected_demand(wn)
+    
+    assert_equal(len(wn.pattern_name_list), 5) # number of original patterns
+    assert_less(abs((demands1/demands0).max().max()-1.5), 0.000001)
+    
+    sim1 = wntr.sim.EpanetSimulator(wn)
+    results1 = sim1.run_sim()
+    demands_sim1 = results1.node['demand'].loc[:,wn.junction_name_list]
+    
+    ### re-assign demands to be 2 times the original demands
+    wn.assign_demand(demands1*2, pattern_prefix='ResetDemand1_')
+
+    demands2 = wntr.metrics.expected_demand(wn)
+    
+    sim = wntr.sim.EpanetSimulator(wn)
+    results2 = sim.run_sim()
+    demands_sim2 = results2.node['demand'].loc[:,wn.junction_name_list]
+    
+    assert_equal(len(wn.pattern_name_list), wn.num_junctions+5)
+    assert_less(abs((demands2/demands1).max().max()-2), 0.000001)
+    assert_less(abs((demands_sim2/demands_sim1).max().max()-2), 0.01)
+    
+    ### re-assign demands using results from the simulation
+    wn.assign_demand(demands_sim2, pattern_prefix='ResetDemand2_')
+
+    demands2 = wntr.metrics.expected_demand(wn)
+    
+    sim = wntr.sim.EpanetSimulator(wn)
+    results2 = sim.run_sim()
+    demands_sim2 = results2.node['demand'].loc[:,wn.junction_name_list]
+    
+    assert_equal(len(wn.pattern_name_list), 2*wn.num_junctions+5)
+    assert_less(abs((demands2/demands1).max().max()-2), 0.01)
+    assert_less(abs((demands_sim2/demands_sim1).max().max()-2), 0.01)
+                
 if __name__ == '__main__':
-    unittest.main()
+    #unittest.main()
+    test_assign_demand()

--- a/wntr/tests/test_network.py
+++ b/wntr/tests/test_network.py
@@ -688,11 +688,14 @@ def test_assign_demand():
     
     inp_file = join(ex_datadir, 'Net3.inp')
     wn = wntr.network.WaterNetworkModel(inp_file)
+    
     demands0 = wntr.metrics.expected_demand(wn)
+    pattern_name0 = wn.get_node('10').demand_timeseries_list[0].pattern_name
     
     wn.options.hydraulic.demand_multiplier = 1.5
     demands1 = wntr.metrics.expected_demand(wn)
     
+    assert_equal(pattern_name0, '1')
     assert_equal(len(wn.pattern_name_list), 5) # number of original patterns
     assert_less(abs((demands1/demands0).max().max()-1.5), 0.000001)
     
@@ -704,11 +707,13 @@ def test_assign_demand():
     wn.assign_demand(demands1*2, pattern_prefix='ResetDemand1_')
 
     demands2 = wntr.metrics.expected_demand(wn)
+    pattern_name = wn.get_node('10').demand_timeseries_list[0].pattern_name
     
     sim = wntr.sim.EpanetSimulator(wn)
     results2 = sim.run_sim()
     demands_sim2 = results2.node['demand'].loc[:,wn.junction_name_list]
     
+    assert_equal(pattern_name, 'ResetDemand1_10')
     assert_equal(len(wn.pattern_name_list), wn.num_junctions+5)
     assert_less(abs((demands2/demands1).max().max()-2), 0.000001)
     assert_less(abs((demands_sim2/demands_sim1).max().max()-2), 0.01)
@@ -717,11 +722,13 @@ def test_assign_demand():
     wn.assign_demand(demands_sim2, pattern_prefix='ResetDemand2_')
 
     demands2 = wntr.metrics.expected_demand(wn)
+    pattern_name = wn.get_node('10').demand_timeseries_list[0].pattern_name
     
     sim = wntr.sim.EpanetSimulator(wn)
     results2 = sim.run_sim()
     demands_sim2 = results2.node['demand'].loc[:,wn.junction_name_list]
     
+    assert_equal(pattern_name, 'ResetDemand2_10')
     assert_equal(len(wn.pattern_name_list), 2*wn.num_junctions+5)
     assert_less(abs((demands2/demands1).max().max()-2), 0.01)
     assert_less(abs((demands_sim2/demands_sim1).max().max()-2), 0.01)


### PR DESCRIPTION
This PR fixes #137.  The assign_demand function now updates demands using the demand_timeseries_list and the function uses the demand multiplier to create a new pattern.  

The input DataFrame that contains new demands can only include junctions as column names, Therefore, if you are using demands that come from simulation results, you need to extract column names associated with junctions.  For example, `results.node['demand'].loc[:,wn.junction_name_list]`.  

The documentation has been updated and tests were added.  

Travis CI test results are available at https://travis-ci.org/github/kaklise/WNTR/builds/685793237
