### PR TITLE
Updates to WNTRSimulator controls

### DIFF
--- a/documentation/whatsnew/v0.2.2.1.rst
+++ b/documentation/whatsnew/v0.2.2.1.rst
@@ -6,6 +6,11 @@ v0.2.2.1
 * Fixed :class:`~wntr.network.model.WaterNetworkModel.assign_demand`. 
   The function now reassigns demands using the demand_timeseries_list and uses the demand 
   multiplier to create a new pattern.
+* Fixed issues in WNTRSimulator controls, including:
+	* Fixed a bug in the tank controls that are used when a pipe entering/leaving the tank has a CV
+	* Fixed a bug in the PSV headloss constraint, which now uses elevation at the start node
+	* Added a tolerance threshold to ValueCondition and TankLevelCondition
+	* Added a tolerance threshold to the condition that activates FCV
 * Updated tests
 * Updated documentation
   

--- a/documentation/whatsnew/v0.2.2.1.rst
+++ b/documentation/whatsnew/v0.2.2.1.rst
@@ -6,11 +6,13 @@ v0.2.2.1
 * Fixed :class:`~wntr.network.model.WaterNetworkModel.assign_demand`. 
   The function now reassigns demands using the demand_timeseries_list and uses the demand 
   multiplier to create a new pattern.
-* Fixed issues in WNTRSimulator controls, including:
-	* Fixed a bug in the tank controls that are used when a pipe entering/leaving the tank has a CV
-	* Fixed a bug in the PSV headloss constraint, which now uses elevation at the start node
-	* Added a tolerance threshold to ValueCondition and TankLevelCondition
-	* Added a tolerance threshold to the condition that activates FCV
+* Fixed issues in WNTRSimulator controls, including
+ 
+  * Fixed a bug in tank controls that are used when a pipe entering/leaving the tank has a CV
+  * Fixed a bug in the PSV headloss constraint, which now uses elevation at the start node
+  * Added a tolerance threshold to ValueCondition and TankLevelCondition
+  * Added a tolerance threshold to the condition that activates FCV
+  
 * Updated tests
 * Updated documentation
   

--- a/wntr/network/controls.py
+++ b/wntr/network/controls.py
@@ -1568,7 +1568,7 @@ class _ActiveFCVCondition(ControlCondition):
             return False
         elif self._fcv.flow < -self._Qtol:
             return False
-        elif self._fcv._internal_status == LinkStatus.Open and self._fcv.flow >= self._fcv.setting:
+        elif self._fcv._internal_status == LinkStatus.Open and self._fcv.flow >= self._fcv.setting + self._Qtol:
             return True
         else:
             return False

--- a/wntr/network/controls.py
+++ b/wntr/network/controls.py
@@ -737,7 +737,7 @@ class ValueCondition(ControlCondition):
         if np.isnan(self._threshold):
             relation = np.greater
             thresh_value = 0.0
-        state = relation(cur_value, thresh_value)
+        state = relation(np.round(cur_value,10), np.round(thresh_value,10))
         return bool(state)
 
 
@@ -788,8 +788,8 @@ class TankLevelCondition(ValueCondition):
         if np.isnan(self._threshold):  # what is this doing?
             relation = np.greater
             thresh_value = 0.0
-        state = relation(cur_value, thresh_value)  # determine if the condition is satisfied
-        if state and not relation(self._last_value, thresh_value):
+        state = relation(np.round(cur_value,10), np.round(thresh_value,10))  # determine if the condition is satisfied
+        if state and not relation(np.round(self._last_value,10), np.round(thresh_value,10)):
             # if the condition is satisfied and the last value did not satisfy the condition, then backtracking
             # is needed.
             # The math.floor is not actually needed, but I leave it here for clarity. We want the backtrack value to be

--- a/wntr/network/model.py
+++ b/wntr/network/model.py
@@ -81,8 +81,8 @@ class WaterNetworkModel(AbstractModel):
 
         # NetworkX Graph to store the pipe connectivity and node coordinates
 
-        self._Htol = 0.00015  # Head tolerance in meters.
-        self._Qtol = 2.8e-5  # Flow tolerance in m^3/s.
+        self._Htol = 0.0001524  # Head tolerance in meters.
+        self._Qtol = 2.83168e-6  # Flow tolerance in m^3/s.
 
         self._labels = None
 
@@ -795,15 +795,15 @@ class WaterNetworkModel(AbstractModel):
             min_head = tank.min_level+tank.elevation
             for link_name in all_links:
                 link = self.get_link(link_name)
-                link_has_cv = False
+                link_has_cv = False # flow leaving the tank (start node = tank)
                 if isinstance(link, Pipe):
                     if link.cv:
-                        if link.end_node == tank_name:
+                        if link.end_node_name == tank_name:
                             continue
                         else:
                             link_has_cv = True
                 elif isinstance(link, Pump):
-                    if link.end_node == tank_name:
+                    if link.end_node_name == tank_name:
                         continue
                     else:
                         link_has_cv = True
@@ -842,15 +842,15 @@ class WaterNetworkModel(AbstractModel):
             max_head = tank.max_level+tank.elevation
             for link_name in all_links:
                 link = self.get_link(link_name)
-                link_has_cv = False
+                link_has_cv = False # flow entering the tank (end node = tank)
                 if isinstance(link, Pipe):
                     if link.cv:
-                        if link.start_node == tank_name:
+                        if link.start_node_name == tank_name:
                             continue
                         else:
                             link_has_cv = True
                 if isinstance(link, Pump):
-                    if link.start_node == tank_name:
+                    if link.start_node_name == tank_name:
                         continue
                     else:
                         link_has_cv = True

--- a/wntr/sim/models/constraint.py
+++ b/wntr/sim/models/constraint.py
@@ -381,7 +381,7 @@ class prv_headloss_constraint(Definition):
     @classmethod
     def build(cls, m, wn, updater, index_over=None):
         """
-        Adds a headloss constraint to the model for the power pumps.
+        Adds a headloss constraint to the model for the pressure reducing valves.
 
         Parameters
         ----------
@@ -477,7 +477,7 @@ class psv_headloss_constraint(Definition):
                     end_h = m.source_head[end_node_name]
 
                 if status is wntr.network.LinkStatus.Active:
-                    con = aml.Constraint(start_h - m.valve_setting[link_name] - m.elevation[end_node_name])
+                    con = aml.Constraint(start_h - m.valve_setting[link_name] - m.elevation[start_node_name])
                 else:
                     assert status == LinkStatus.Open
                     con = aml.Constraint(m.minor_loss[link_name]*f**2 - start_h + end_h)


### PR DESCRIPTION
This PR addresses issues with the WNTRSimulator controls that were identified when working on #108. Updates include:
* Fixed a bug in tank controls that are used when a pipe entering/leaving the tank has a CV
* Fixed a bug in the PSV headloss constraint, which now uses elevation at the start node
* Added a tolerance threshold to ValueCondition and TankLevelCondition
* Added a tolerance threshold to the condition that activates FCV

Travis CI test results are available at https://travis-ci.org/github/kaklise/WNTR/builds/686229500