### PR TITLE
adding description to getting_started example

### DIFF
--- a/examples/getting_started.py
+++ b/examples/getting_started.py
@@ -1,5 +1,11 @@
 import wntr
-
+"""
+The following example runs a simple example that uses EPANET Example Network 3 (Net3). This example demonstrates how to:
+* Import WNTR
+* Generate a water network model
+* Simulate hydraulics
+* Plot simulation results on the network
+"""
 # Create a water network model
 inp_file = 'networks/Net3.inp'
 wn = wntr.network.WaterNetworkModel(inp_file)


### PR DESCRIPTION
adding description to getting_started example from docs

``` 
The following example runs a simple example that uses EPANET Example Network 3 (Net3). This example demonstrates how to:
* Import WNTR
* Generate a water network model
* Simulate hydraulics
* Plot simulation results on the network
```