### PR TITLE
Fix missing output attributes that impacted control actions

### DIFF
--- a/documentation/resultsobject.rst
+++ b/documentation/resultsobject.rst
@@ -96,7 +96,7 @@ For example, link results generated with the EpanetSimulator have the following 
 
     >>> link_keys = results.link.keys()
     >>> print(link_keys) # doctest: +SKIP
-    dict_keys(['flowrate', 'frictionfact', 'headloss', 'linkquality', 'rxnrate', 'setting', 'status', 'velocity']) 
+    dict_keys(['flowrate', 'friction_factor', 'headloss', 'quality', 'reaction_rate', 'setting', 'status', 'velocity']) 
 
 To access node pressure over all nodes and times:
 

--- a/wntr/epanet/io.py
+++ b/wntr/epanet/io.py
@@ -1082,7 +1082,7 @@ class InpFile(object):
                     current[1].upper() == 'ACTIVE'):
                 new_status = LinkStatus[current[1].upper()]
                 link.initial_status = new_status
-                link.status = new_status
+                link._user_status = new_status
             else:
                 if isinstance(link, wntr.network.Valve):
                     new_status = LinkStatus.Active
@@ -1100,7 +1100,7 @@ class InpFile(object):
                     setting = float(current[1])
 #                link.setting = setting
                 link.initial_setting = setting
-                link.status = new_status
+                link._user_status = new_status
                 link.initial_status = new_status
 
     def _write_status(self, f, wn):

--- a/wntr/epanet/io.py
+++ b/wntr/epanet/io.py
@@ -2944,13 +2944,13 @@ class BinFile(object):
                 # Water Quality Results (node and link)
                 if self.quality_type is QualType.Chem:
                     self.results.node['quality'] = QualParam.Concentration._to_si(self.flow_units, df['quality'], mass_units=self.mass_units)
-                    self.results.link['linkquality'] = QualParam.Concentration._to_si(self.flow_units, df['linkquality'], mass_units=self.mass_units)
+                    self.results.link['quality'] = QualParam.Concentration._to_si(self.flow_units, df['linkquality'], mass_units=self.mass_units)
                 elif self.quality_type is QualType.Age:
                     self.results.node['quality'] = QualParam.WaterAge._to_si(self.flow_units, df['quality'], mass_units=self.mass_units)
-                    self.results.link['linkquality'] = QualParam.WaterAge._to_si(self.flow_units, df['linkquality'], mass_units=self.mass_units)
+                    self.results.link['quality'] = QualParam.WaterAge._to_si(self.flow_units, df['linkquality'], mass_units=self.mass_units)
                 else:
                     self.results.node['quality'] = df['quality']
-                    self.results.link['linkquality'] = df['linkquality']
+                    self.results.link['quality'] = df['linkquality']
 
                 # Link Results
                 self.results.link['flowrate'] = HydParam.Flow._to_si(self.flow_units, df['flow'])
@@ -2972,8 +2972,8 @@ class BinFile(object):
                 settings[:, linktype == EN.PBV] = to_si(self.flow_units, settings[:, linktype == EN.PBV], HydParam.Pressure)
                 settings[:, linktype == EN.FCV] = to_si(self.flow_units, settings[:, linktype == EN.FCV], HydParam.Flow)
                 self.results.link['setting'] = pd.DataFrame(data=settings, columns=linknames, index=reporttimes)
-                self.results.link['frictionfact'] = df['frictionfactor']
-                self.results.link['rxnrate'] = df['reactionrate']
+                self.results.link['friction_factor'] = df['frictionfactor']
+                self.results.link['reaction_rate'] = df['reactionrate']
                 
             logger.debug('... read epilog ...')
             # Read the averages and then the number of periods for checks

--- a/wntr/network/base.py
+++ b/wntr/network/base.py
@@ -110,7 +110,9 @@ class Node(six.with_metaclass(abc.ABCMeta, object)):
     def __init__(self, wn, name):
         self._name = name
         self._head = None
-        self._demand = None  
+        self._demand = None
+        self._pressure = None
+        self._quality = None
         self._leak_demand = None
         self._initial_quality = None
         self._tag = None
@@ -158,19 +160,29 @@ class Node(six.with_metaclass(abc.ABCMeta, object)):
 
     @property
     def head(self):
-        """float: The current head at the node"""
+        """float: The current head at the node (total head)"""
         return self._head
-    @head.setter
-    def head(self, value):
-        self._head = value
+    # @head.setter
+    # def head(self, value):
+    #     self._head = value
 
     @property
     def demand(self):
-        """float: The current demand at the node"""
+        """float: The current demand at the node (actual demand)"""
         return self._demand
-    @demand.setter
-    def demand(self, value):
-        self._demand = value
+    # @demand.setter
+    # def demand(self, value):
+    #     self._demand = value
+
+    @property
+    def pressure(self):
+        """float : The current pressure at the node"""
+        return self._pressure
+
+    @property
+    def quality(self):
+        """float : The current quality at the node"""
+        return self._quality
 
     @property
     def leak_demand(self):

--- a/wntr/network/base.py
+++ b/wntr/network/base.py
@@ -96,11 +96,20 @@ class Node(six.with_metaclass(abc.ABCMeta, object)):
 
         name
         node_type
-        head
-        demand
         coordinates
         initial_quality
         tag
+    
+
+    .. rubric:: Read-only simulation results
+
+    The following attributes are read-only. The values are the final calculated
+    value from a simulation.
+
+    .. autosummary::
+
+        head
+        demand
         leak_demand
         leak_status
         leak_area
@@ -160,7 +169,7 @@ class Node(six.with_metaclass(abc.ABCMeta, object)):
 
     @property
     def head(self):
-        """float: The current head at the node (total head)"""
+        """float: (read-only) the current simulation head at the node (total head)"""
         return self._head
     # @head.setter
     # def head(self, value):
@@ -168,7 +177,7 @@ class Node(six.with_metaclass(abc.ABCMeta, object)):
 
     @property
     def demand(self):
-        """float: The current demand at the node (actual demand)"""
+        """float: (read-only) the current simulation demand at the node (actual demand)"""
         return self._demand
     # @demand.setter
     # def demand(self, value):
@@ -176,45 +185,45 @@ class Node(six.with_metaclass(abc.ABCMeta, object)):
 
     @property
     def pressure(self):
-        """float : The current pressure at the node"""
+        """float : (read-only) the current simulation pressure at the node"""
         return self._pressure
 
     @property
     def quality(self):
-        """float : The current quality at the node"""
+        """float : (read-only) the current simulation quality at the node"""
         return self._quality
 
     @property
     def leak_demand(self):
-        """float: The current demand at the node"""
+        """float: (read-only) the current simulation leak demand at the node"""
         return self._leak_demand
-    @leak_demand.setter
-    def leak_demand(self, value):
-        self._leak_demand = value
+    # @leak_demand.setter
+    # def leak_demand(self, value):
+    #     self._leak_demand = value
 
     @property
     def leak_status(self):
-        """bool: The current leak status at the node"""
+        """bool:(read-only) the current simulation leak status at the node"""
         return self._leak_status
-    @leak_status.setter
-    def leak_status(self, value):
-        self._leak_status = value
+    # @leak_status.setter
+    # def leak_status(self, value):
+    #     self._leak_status = value
 
     @property
     def leak_area(self):
-        """float: The leak area at the node"""
+        """float: (read-only) the current simulation leak area at the node"""
         return self._leak_area
-    @leak_area.setter
-    def leak_area(self, value):
-        self._leak_area = value
+    # @leak_area.setter
+    # def leak_area(self, value):
+    #     self._leak_area = value
 
     @property
     def leak_discharge_coeff(self):
-        """float: The leak discharge coefficient"""
+        """float: (read-only) the current simulation leak discharge coefficient"""
         return self._leak_discharge_coeff
-    @leak_discharge_coeff.setter
-    def leak_discharge_coeff(self, value):
-        self._leak_discharge_coeff = value
+    # @leak_discharge_coeff.setter
+    # def leak_discharge_coeff(self, value):
+    #     self._leak_discharge_coeff = value
 
     @property
     def node_type(self):
@@ -306,11 +315,13 @@ class Link(six.with_metaclass(abc.ABCMeta, object)):
         end_node_name
         initial_status
         initial_setting
-        setting
         tag
         vertices
 
-    .. rubric:: Result attributes
+    .. rubric:: Read-only simulation results
+
+    The following attributes are read-only. The values are the final calculated
+    value from a simulation.
 
     .. autosummary::
 
@@ -318,7 +329,7 @@ class Link(six.with_metaclass(abc.ABCMeta, object)):
         headloss
         quality
         status
-
+        setting
 
     """
     def __init__(self, wn, link_name, start_node_name, end_node_name):
@@ -348,6 +359,7 @@ class Link(six.with_metaclass(abc.ABCMeta, object)):
         self._prev_setting = None
         self._setting = None
         self._flow = None
+        self._velocity = None
         self._is_isolated = False
         self._quality = None
         self._headloss = None
@@ -450,8 +462,13 @@ class Link(six.with_metaclass(abc.ABCMeta, object)):
 
     @property
     def flow(self):
-        """float: Current flow through the link (read only)"""
+        """float: (read-only) current simulated flow through the link"""
         return self._flow
+    
+    @property
+    def velocity(self):
+        """float: (read-only) current simulated velocity through the link"""
+        return self._velocity
     
     @property
     @abc.abstractmethod
@@ -459,29 +476,33 @@ class Link(six.with_metaclass(abc.ABCMeta, object)):
         """:class:`~wntr.network.base.LinkStatus`: (**abstract**) current status of the link"""
         pass
     @status.setter
-    @abc.abstractmethod
+    # @abc.abstractmethod
     def status(self, status):
         raise RuntimeError("The status attribute is an output (result) property. Setting status by"
-                            " the user has been deprecated to avoid confusion.")
+                            " the user has been deprecated to avoid confusion. To change the simulation"
+                            " behavior, use initial_status.")
         # self._user_status = status
     
     @property
     def quality(self):
-        """float : current average link quality"""
+        """float : (read-only) current simulated average link quality"""
         return self._quality
 
     @property
     def headloss(self):
-        """float : current headloss"""
+        """float : (read-only) current simulated headloss"""
         return self._headloss
 
     @property
     def setting(self):
-        """float: The current setting of the link"""
+        """float: (read-only) current simulated setting of the link"""
         return self._setting
     @setting.setter
     def setting(self, setting):
-        self._setting = setting
+        raise RuntimeError("The setting attribute is an output (result) property. Setting the setting by"
+                            " the user has been deprecated to avoid confusion. To change the simulation"
+                            " behavior, use initial_setting.")
+        # self._setting = setting
     
     @property
     def tag(self):

--- a/wntr/network/base.py
+++ b/wntr/network/base.py
@@ -306,10 +306,18 @@ class Link(six.with_metaclass(abc.ABCMeta, object)):
         end_node_name
         initial_status
         initial_setting
-        status
         setting
         tag
         vertices
+
+    .. rubric:: Result attributes
+
+    .. autosummary::
+
+        flow
+        headloss
+        quality
+        status
 
 
     """
@@ -341,6 +349,8 @@ class Link(six.with_metaclass(abc.ABCMeta, object)):
         self._setting = None
         self._flow = None
         self._is_isolated = False
+        self._quality = None
+        self._headloss = None
 
     def _compare(self, other):
         """
@@ -451,8 +461,20 @@ class Link(six.with_metaclass(abc.ABCMeta, object)):
     @status.setter
     @abc.abstractmethod
     def status(self, status):
-        self._user_status = status
+        raise RuntimeError("The status attribute is an output (result) property. Setting status by"
+                            " the user has been deprecated to avoid confusion.")
+        # self._user_status = status
     
+    @property
+    def quality(self):
+        """float : current average link quality"""
+        return self._quality
+
+    @property
+    def headloss(self):
+        """float : current headloss"""
+        return self._headloss
+
     @property
     def setting(self):
         """float: The current setting of the link"""

--- a/wntr/network/controls.py
+++ b/wntr/network/controls.py
@@ -1723,7 +1723,10 @@ class ControlAction(BaseControlAction):
         return self._value
 
     def run_control_action(self):
-        setattr(self._target_obj, self._attribute, self._value)
+        if self._attribute == 'status':
+            setattr(self._target_obj, '_user_status', self._value)
+        else:
+            setattr(self._target_obj, self._attribute, self._value)
         self.notify()
 
     def target(self):

--- a/wntr/network/controls.py
+++ b/wntr/network/controls.py
@@ -1704,6 +1704,13 @@ class ControlAction(BaseControlAction):
         self._target_obj = target_obj
         self._attribute = attribute
         self._value = value
+        self._private_attribute = attribute
+        if attribute == 'status':
+            self._private_attribute = '_user_status'
+        elif attribute == 'leak_status':
+            self._private_attribute = '_leak_status'
+        elif attribute == 'setting':
+            self._private_attribute = '_setting'
 
     def requires(self):
         return OrderedSet([self._target_obj])
@@ -1723,10 +1730,7 @@ class ControlAction(BaseControlAction):
         return self._value
 
     def run_control_action(self):
-        if self._attribute == 'status':
-            setattr(self._target_obj, '_user_status', self._value)
-        else:
-            setattr(self._target_obj, self._attribute, self._value)
+        setattr(self._target_obj, self._private_attribute, self._value)
         self.notify()
 
     def target(self):

--- a/wntr/network/elements.py
+++ b/wntr/network/elements.py
@@ -380,7 +380,7 @@ class Tank(Node):
         self._min_level=0.0
         self._max_level=6.096
         self._diameter=15.24
-        self.head = self.elevation + self._init_level
+        self._head = self.elevation + self._init_level
         self._prev_head = self.head
         self._min_vol=0 
         self._vol_curve_name = None
@@ -500,7 +500,7 @@ class Tank(Node):
     @init_level.setter
     def init_level(self, value):
         self._init_level = value
-        self.head = self.elevation+self._init_level
+        self._head = self.elevation+self._init_level
 
     @property
     def node_type(self):
@@ -552,7 +552,16 @@ class Tank(Node):
         """Returns tank level = head - elevation (read only)"""
         return self.head - self.elevation
     
+    @property
+    def net_inflow(self):
+        """float : the flow into the tank (negative demand)"""
+        return 0.0 - self.demand
     
+    @property
+    def pressure(self):
+        """float : current pressure (head - elevation)"""
+        return self._head - self.elevation
+
     def get_volume(self, level=None):
         """
         Returns tank volume at a given level
@@ -737,6 +746,16 @@ class Reservoir(Node):
         if name is not None:
             self._pattern_reg.add_usage(name, (self.name, 'Reservoir'))
         self._head_timeseries.pattern_name = name
+
+    @property
+    def net_inflow(self):
+        """float : the flow into the tank (negative demand)"""
+        return 0.0 - self.demand
+
+    @property
+    def pressure(self):
+        """float : current pressure (0.0 for reservoirs)"""
+        return 0.0
 
 
 class Pipe(Link):

--- a/wntr/network/elements.py
+++ b/wntr/network/elements.py
@@ -86,12 +86,8 @@ class Junction(Node):
         coordinates
         initial_quality
         tag
-        leak_demand
-        leak_status
-        leak_area
-        leak_discharge_coeff
 
-    .. rubric:: Results Attributes
+    .. rubric:: Read-only simulation results
 
     .. autosummary::
 
@@ -99,6 +95,10 @@ class Junction(Node):
         head
         pressure
         quality
+        leak_demand
+        leak_status
+        leak_area
+        leak_discharge_coeff
     
     """
     def __init__(self, name, wn):
@@ -109,9 +109,9 @@ class Junction(Node):
         self._minimum_pressure = None
         self._emitter_coefficient = None
         self._leak = False
-        self.leak_status = False
-        self.leak_area = 0.0
-        self.leak_discharge_coeff = 0.0
+        self._leak_status = False
+        self._leak_area = 0.0
+        self._leak_discharge_coeff = 0.0
         self._leak_start_control_name = 'junction'+self._name+'start_leak_control'
         self._leak_end_control_name = 'junction'+self._name+'end_leak_control'
         
@@ -256,8 +256,8 @@ class Junction(Node):
         from wntr.network.controls import ControlAction, Control
         
         self._leak = True
-        self.leak_area = area
-        self.leak_discharge_coeff = discharge_coeff
+        self._leak_area = area
+        self._leak_discharge_coeff = discharge_coeff
 
         if start_time is not None:
             start_control_action = ControlAction(self, 'leak_status', True)
@@ -362,7 +362,6 @@ class Tank(Node):
         init_level
         min_level
         max_level
-        level
         diameter
         min_vol
         vol_curve_name
@@ -374,19 +373,19 @@ class Tank(Node):
         coordinates
         initial_quality
         tag
+
+    .. rubric:: Read-only simulation results
+
+    .. autosummary::
+
+        head
+        level
+        pressure
+        quality
         leak_demand
         leak_status
         leak_area
         leak_discharge_coeff
-
-    .. rubric:: Result attributes
-
-    .. autosummary::
-
-        net_inflow
-        head
-        pressure
-        quality
 
     """
 
@@ -406,9 +405,9 @@ class Tank(Node):
         self._bulk_coeff = None
         self._overflow = False
         self._leak = False
-        self.leak_status = False
-        self.leak_area = 0.0
-        self.leak_discharge_coeff = 0.0
+        self._leak_status = False
+        self._leak_area = 0.0
+        self._leak_discharge_coeff = 0.0
         self._leak_start_control_name = 'tank'+self._name+'start_leak_control'
         self._leak_end_control_name = 'tank'+self._name+'end_leak_control'
 
@@ -566,17 +565,12 @@ class Tank(Node):
 
     @property
     def level(self):
-        """Returns tank level = head - elevation (read only)"""
+        """float : (read-only) the current simulation tank level (= head - elevation)"""
         return self.head - self.elevation
     
     @property
-    def net_inflow(self):
-        """float : the flow into the tank (negative demand)"""
-        return 0.0 - self.demand
-    
-    @property
     def pressure(self):
-        """float : current pressure (head - elevation)"""
+        """float : (read-only) the current simulation pressure (head - elevation)"""
         return self._head - self.elevation
 
     def get_volume(self, level=None):
@@ -648,8 +642,8 @@ class Tank(Node):
         from wntr.network.controls import ControlAction, Control
         
         self._leak = True
-        self.leak_area = area
-        self.leak_discharge_coeff = discharge_coeff
+        self._leak_area = area
+        self._leak_discharge_coeff = discharge_coeff
 
         if start_time is not None:
             start_control_action = ControlAction(self, 'leak_status', True)
@@ -707,21 +701,15 @@ class Reservoir(Node):
         base_head
         head_pattern_name
         head_timeseries
-        head
-        demand
-        leak_demand
-        leak_status
-        leak_area
-        leak_discharge_coeff
         tag
         initial_quality
         coordinates
 
-    .. rubric:: Result attributes
+    .. rubric:: Read-only simulation results
 
     .. autosummary::
 
-        net_inflow
+        demand
         head
         pressure
         quality
@@ -774,13 +762,8 @@ class Reservoir(Node):
         self._head_timeseries.pattern_name = name
 
     @property
-    def net_inflow(self):
-        """float : the flow into the tank (negative demand)"""
-        return 0.0 - self.demand
-
-    @property
     def pressure(self):
-        """float : current pressure (0.0 for reservoirs)"""
+        """float : (read-only) the current simulation pressure (0.0 for reservoirs)"""
         return 0.0
 
 
@@ -827,7 +810,8 @@ class Pipe(Link):
         tag
         vertices
 
-    .. rubric:: Result attributes
+
+    .. rubric:: Read-only simulation results
 
     .. autosummary::
 
@@ -940,23 +924,15 @@ class Pipe(Link):
             return LinkStatus.Closed
         else:
             return self._user_status
-    @status.setter
-    def status(self, status):
-        self._user_status = status
-
-    @property
-    def velocity(self):
-        """float : current velocity in the pipe"""
-        return self._velocity
 
     @property
     def friction_factor(self):
-        """float : current friction factor in the pipe"""
+        """float : (read-only) the current simulation friction factor in the pipe"""
         return self._friction_factor
 
     @property
     def reaction_rate(self):
-        """float : current reaction rate in the pipe"""
+        """float : (read-only) the current simulation reaction rate in the pipe"""
         return self._reaction_rate
 
 
@@ -1001,20 +977,20 @@ class Pump(Link):
         efficiency
         energy_price
         energy_pattern
-        status
-        setting
         tag
         vertices
 
-    .. rubric:: Result attributes
+
+    .. rubric:: Read-only simulation results
 
     .. autosummary::
 
         flow
         headloss
+        velocity
         quality
         status
-
+        setting
 
     """
 
@@ -1068,9 +1044,6 @@ class Pump(Link):
             return LinkStatus.Closed
         else:
             return self._user_status
-    @status.setter
-    def status(self, status):
-        self._user_status = status
 
     @property
     def link_type(self):
@@ -1205,11 +1178,20 @@ class HeadPump(Pump):
         efficiency
         energy_price
         energy_pattern
-        status
-        setting
         tag
         vertices
 
+
+    .. rubric:: Read-only simulation results
+
+    .. autosummary::
+
+        flow
+        headloss
+        velocity
+        quality
+        status
+        setting
 
     """
 #    def __init__(self, name, start_node_name, end_node_name, wn):
@@ -1414,10 +1396,20 @@ class PowerPump(Pump):
         efficiency
         energy_price
         energy_pattern
-        setting
         tag
         vertices
 
+
+    .. rubric:: Read-only simulation results
+
+    .. autosummary::
+
+        flow
+        headloss
+        velocity
+        quality
+        status
+        setting
 
     """
     
@@ -1490,9 +1482,9 @@ class Valve(Link):
         initial_status
         initial_setting
         valve_type
-        setting
         tag
         vertices
+
 
     .. rubric:: Result attributes
 
@@ -1503,6 +1495,7 @@ class Valve(Link):
         headloss
         quality
         status
+        setting
 
     """
     
@@ -1539,17 +1532,6 @@ class Valve(Link):
             return LinkStatus.Open
         else:
             return self._internal_status
-
-    @status.setter
-    def status(self, status):
-        raise RuntimeError("The status attribute is an output (result) property. Setting status by"
-                            " the user has been deprecated to avoid confusion.")
-
-        self._user_status = status
-
-    @property
-    def velocity(self):
-        return self._velocity
 
     @property
     def link_type(self):
@@ -1597,10 +1579,20 @@ class PRValve(Valve):
         initial_status
         initial_setting
         valve_type
-        status
-        setting
         tag
         vertices
+
+
+    .. rubric:: Result attributes
+
+    .. autosummary::
+
+        flow
+        velocity
+        headloss
+        quality
+        status
+        setting
 
     """
     
@@ -1648,10 +1640,20 @@ class PSValve(Valve):
         initial_status
         initial_setting
         valve_type
-        status
-        setting
         tag
         vertices
+
+
+    .. rubric:: Result attributes
+
+    .. autosummary::
+
+        flow
+        velocity
+        headloss
+        quality
+        status
+        setting
 
     """
     
@@ -1699,10 +1701,20 @@ class PBValve(Valve):
         initial_status
         initial_setting
         valve_type
-        status
-        setting
         tag
         vertices
+
+
+    .. rubric:: Result attributes
+
+    .. autosummary::
+
+        flow
+        velocity
+        headloss
+        quality
+        status
+        setting
 
     """
     
@@ -1750,10 +1762,19 @@ class FCValve(Valve):
         initial_status
         initial_setting
         valve_type
-        status
-        setting
         tag
         vertices
+
+    .. rubric:: Result attributes
+
+    .. autosummary::
+
+        flow
+        velocity
+        headloss
+        quality
+        status
+        setting
 
     """
     
@@ -1801,10 +1822,20 @@ class TCValve(Valve):
         initial_status
         initial_setting
         valve_type
-        status
-        setting
         tag
         vertices
+
+
+    .. rubric:: Result attributes
+
+    .. autosummary::
+
+        flow
+        velocity
+        headloss
+        quality
+        status
+        setting
 
     """
     
@@ -1854,10 +1885,20 @@ class GPValve(Valve):
         valve_type
         headloss_curve
         headloss_curve_name
-        status
-        setting
         tag
         vertices
+
+
+    .. rubric:: Result attributes
+
+    .. autosummary::
+
+        flow
+        velocity
+        headloss
+        quality
+        status
+        setting
 
     """
     

--- a/wntr/network/elements.py
+++ b/wntr/network/elements.py
@@ -91,7 +91,15 @@ class Junction(Node):
         leak_area
         leak_discharge_coeff
 
+    .. rubric:: Results Attributes
 
+    .. autosummary::
+
+        demand
+        head
+        pressure
+        quality
+    
     """
     def __init__(self, name, wn):
         super(Junction, self).__init__(wn, name)
@@ -370,6 +378,15 @@ class Tank(Node):
         leak_status
         leak_area
         leak_discharge_coeff
+
+    .. rubric:: Result attributes
+
+    .. autosummary::
+
+        net_inflow
+        head
+        pressure
+        quality
 
     """
 
@@ -700,6 +717,15 @@ class Reservoir(Node):
         initial_quality
         coordinates
 
+    .. rubric:: Result attributes
+
+    .. autosummary::
+
+        net_inflow
+        head
+        pressure
+        quality
+
     """
     
     def __init__(self, name, wn, base_head=0.0, head_pattern=None):
@@ -796,14 +822,22 @@ class Pipe(Link):
         bulk_coeff
         wall_coeff
         initial_status
-        initial_setting
         start_node
         end_node
-        status
-        setting
         tag
         vertices
 
+    .. rubric:: Result attributes
+
+    .. autosummary::
+
+        flow
+        velocity
+        headloss
+        friction_factor
+        reaction_rate
+        quality
+        status
 
     """
 
@@ -816,6 +850,9 @@ class Pipe(Link):
         self._cv = False
         self._bulk_coeff = None
         self._wall_coeff = None
+        self._velocity = None
+        self._friction_factor = None
+        self._reaction_rate = None
         
     def __repr__(self):
         return "<Pipe '{}' from '{}' to '{}', length={}, diameter={}, roughness={}, minor_loss={}, check_valve={}, status={}>".format(self._link_name,
@@ -907,6 +944,21 @@ class Pipe(Link):
     def status(self, status):
         self._user_status = status
 
+    @property
+    def velocity(self):
+        """float : current velocity in the pipe"""
+        return self._velocity
+
+    @property
+    def friction_factor(self):
+        """float : current friction factor in the pipe"""
+        return self._friction_factor
+
+    @property
+    def reaction_rate(self):
+        """float : current reaction rate in the pipe"""
+        return self._reaction_rate
+
 
 class Pump(Link):
     """
@@ -953,6 +1005,15 @@ class Pump(Link):
         setting
         tag
         vertices
+
+    .. rubric:: Result attributes
+
+    .. autosummary::
+
+        flow
+        headloss
+        quality
+        status
 
 
     """
@@ -1353,7 +1414,6 @@ class PowerPump(Pump):
         efficiency
         energy_price
         energy_pattern
-        status
         setting
         tag
         vertices
@@ -1430,10 +1490,19 @@ class Valve(Link):
         initial_status
         initial_setting
         valve_type
-        status
         setting
         tag
         vertices
+
+    .. rubric:: Result attributes
+
+    .. autosummary::
+
+        flow
+        velocity
+        headloss
+        quality
+        status
 
     """
     
@@ -1444,6 +1513,7 @@ class Valve(Link):
         self._initial_status = LinkStatus.Active
         self._user_status = LinkStatus.Active
         self._initial_setting = 0.0
+        self._velocity = None
 
     def __repr__(self):
         fmt = "<Valve '{}' from '{}' to '{}', valve_type='{}', diameter={}, minor_loss={}, setting={}, status={}>"
@@ -1472,7 +1542,14 @@ class Valve(Link):
 
     @status.setter
     def status(self, status):
+        raise RuntimeError("The status attribute is an output (result) property. Setting status by"
+                            " the user has been deprecated to avoid confusion.")
+
         self._user_status = status
+
+    @property
+    def velocity(self):
+        return self._velocity
 
     @property
     def link_type(self):

--- a/wntr/network/model.py
+++ b/wntr/network/model.py
@@ -1724,23 +1724,23 @@ class WaterNetworkModel(AbstractModel):
         self._prev_sim_time = None
 
         for name, node in self.nodes(Junction):
-            node.head = None
-            node.demand = None
+            node._head = None
+            node._demand = None
             node.leak_demand = None
             node.leak_status = False
             node._is_isolated = False
 
         for name, node in self.nodes(Tank):
-            node.head = node.init_level+node.elevation
+            node._head = node.init_level+node.elevation
             node._prev_head = node.head
-            node.demand = None
+            node._demand = None
             node.leak_demand = None
             node.leak_status = False
             node._is_isolated = False
 
         for name, node in self.nodes(Reservoir):
-            node.head = None  # node.head_timeseries.base_value
-            node.demand = None
+            node._head = None  # node.head_timeseries.base_value
+            node._demand = None
             node.leak_demand = None
             node._is_isolated = False
 

--- a/wntr/network/model.py
+++ b/wntr/network/model.py
@@ -1726,27 +1726,27 @@ class WaterNetworkModel(AbstractModel):
         for name, node in self.nodes(Junction):
             node._head = None
             node._demand = None
-            node.leak_demand = None
-            node.leak_status = False
+            node._leak_demand = None
+            node._leak_status = False
             node._is_isolated = False
 
         for name, node in self.nodes(Tank):
             node._head = node.init_level+node.elevation
             node._prev_head = node.head
             node._demand = None
-            node.leak_demand = None
-            node.leak_status = False
+            node._leak_demand = None
+            node._leak_status = False
             node._is_isolated = False
 
         for name, node in self.nodes(Reservoir):
             node._head = None  # node.head_timeseries.base_value
             node._demand = None
-            node.leak_demand = None
+            node._leak_demand = None
             node._is_isolated = False
 
         for name, link in self.links(Pipe):
             link._user_status = link.initial_status
-            link.setting = link.initial_setting
+            link._setting = link.initial_setting
             link._internal_status = LinkStatus.Active
             link._is_isolated = False
             link._flow = None
@@ -1764,7 +1764,7 @@ class WaterNetworkModel(AbstractModel):
 
         for name, link in self.links(Valve):
             link._user_status = link.initial_status
-            link.setting = link.initial_setting
+            link._setting = link.initial_setting
             link._internal_status = LinkStatus.Active
             link._is_isolated = False
             link._flow = None
@@ -2632,23 +2632,23 @@ class LinkRegistry(Registry):
         if valve_type == 'PRV':
             valve = PRValve(name, start_node_name, end_node_name, self)
             valve.initial_setting = setting
-            valve.setting = setting
+            valve._setting = setting
         elif valve_type == 'PSV':
             valve = PSValve(name, start_node_name, end_node_name, self)
             valve.initial_setting = setting
-            valve.setting = setting
+            valve._setting = setting
         elif valve_type == 'PBV':
             valve = PBValve(name, start_node_name, end_node_name, self)
             valve.initial_setting = setting
-            valve.setting = setting
+            valve._setting = setting
         elif valve_type == 'FCV':
             valve = FCValve(name, start_node_name, end_node_name, self)
             valve.initial_setting = setting
-            valve.setting = setting
+            valve._setting = setting
         elif valve_type == 'TCV':
             valve = TCValve(name, start_node_name, end_node_name, self)
             valve.initial_setting = setting
-            valve.setting = setting
+            valve._setting = setting
         elif valve_type == 'GPV':
             valve = GPValve(name, start_node_name, end_node_name, self)
             valve.headloss_curve_name = setting

--- a/wntr/network/model.py
+++ b/wntr/network/model.py
@@ -1745,7 +1745,7 @@ class WaterNetworkModel(AbstractModel):
             node._is_isolated = False
 
         for name, link in self.links(Pipe):
-            link.status = link.initial_status
+            link._user_status = link.initial_status
             link.setting = link.initial_setting
             link._internal_status = LinkStatus.Active
             link._is_isolated = False
@@ -1753,7 +1753,7 @@ class WaterNetworkModel(AbstractModel):
             link._prev_setting = None
 
         for name, link in self.links(Pump):
-            link.status = link.initial_status
+            link._user_status = link.initial_status
             link._internal_status = LinkStatus.Active
             link._is_isolated = False
             link._flow = None
@@ -1763,7 +1763,7 @@ class WaterNetworkModel(AbstractModel):
             link._prev_setting = None
 
         for name, link in self.links(Valve):
-            link.status = link.initial_status
+            link._user_status = link.initial_status
             link.setting = link.initial_setting
             link._internal_status = LinkStatus.Active
             link._is_isolated = False
@@ -2553,7 +2553,7 @@ class LinkRegistry(Registry):
         pipe.roughness = roughness
         pipe.minor_loss = minor_loss
         pipe.initial_status = status
-        pipe.status = status
+        pipe._user_status = status
         pipe.cv = check_valve_flag
         self[name] = pipe
 

--- a/wntr/sim/hydraulics.py
+++ b/wntr/sim/hydraulics.py
@@ -326,7 +326,7 @@ def store_results_in_network(wn, m):
             node._head = 0
             node._demand = 0
             node._pressure = 0
-            node.leak_demand = 0
+            node._leak_demand = 0
         else:
             node._head = m.head[name].value
             node._pressure = m.head[name].value - node.elevation
@@ -335,21 +335,21 @@ def store_results_in_network(wn, m):
             else:
                 node._demand = m.expected_demand[name].value
             if node.leak_status:
-                node.leak_demand = m.leak_rate[name].value
+                node._leak_demand = m.leak_rate[name].value
             else:
-                node.leak_demand = 0
+                node._leak_demand = 0
 
     for name, node in wn.tanks():
         if node.leak_status:
-            node.leak_demand = m.leak_rate[name].value
+            node._leak_demand = m.leak_rate[name].value
         else:
-            node.leak_demand = 0
+            node._leak_demand = 0
         node._demand = (sum(wn.get_link(link_name).flow for link_name in wn.get_links_for_node(name, 'INLET')) -
                        sum(wn.get_link(link_name).flow for link_name in wn.get_links_for_node(name, 'OUTLET')) -
-                       node.leak_demand)
+                       node._leak_demand)
 
     for name, node in wn.reservoirs():
         node._head = node.head_timeseries.at(wn.sim_time)
-        node.leak_demand = 0
+        node._leak_demand = 0
         node._demand = (sum(wn.get_link(link_name).flow for link_name in wn.get_links_for_node(name, 'INLET')) -
                        sum(wn.get_link(link_name).flow for link_name in wn.get_links_for_node(name, 'OUTLET')))

--- a/wntr/sim/hydraulics.py
+++ b/wntr/sim/hydraulics.py
@@ -186,7 +186,7 @@ def update_tank_heads(wn):
             level_new = np.interp(V1,volume_y,level_x)
             delta_h = level_new - cur_level
                 
-        tank.head = tank._prev_head + delta_h
+        tank._head = tank._prev_head + delta_h
             
 
 
@@ -322,15 +322,17 @@ def store_results_in_network(wn, m):
 
     for name, node in wn.junctions():
         if node._is_isolated:
-            node.head = 0
-            node.demand = 0
+            node._head = 0
+            node._demand = 0
+            node._pressure = 0
             node.leak_demand = 0
         else:
-            node.head = m.head[name].value
+            node._head = m.head[name].value
+            node._pressure = m.head[name].value - node.elevation
             if mode in ['PDD', 'PDA']:
-                node.demand = m.demand[name].value
+                node._demand = m.demand[name].value
             else:
-                node.demand = m.expected_demand[name].value
+                node._demand = m.expected_demand[name].value
             if node.leak_status:
                 node.leak_demand = m.leak_rate[name].value
             else:
@@ -341,12 +343,12 @@ def store_results_in_network(wn, m):
             node.leak_demand = m.leak_rate[name].value
         else:
             node.leak_demand = 0
-        node.demand = (sum(wn.get_link(link_name).flow for link_name in wn.get_links_for_node(name, 'INLET')) -
+        node._demand = (sum(wn.get_link(link_name).flow for link_name in wn.get_links_for_node(name, 'INLET')) -
                        sum(wn.get_link(link_name).flow for link_name in wn.get_links_for_node(name, 'OUTLET')) -
                        node.leak_demand)
 
     for name, node in wn.reservoirs():
-        node.head = node.head_timeseries.at(wn.sim_time)
+        node._head = node.head_timeseries.at(wn.sim_time)
         node.leak_demand = 0
-        node.demand = (sum(wn.get_link(link_name).flow for link_name in wn.get_links_for_node(name, 'INLET')) -
+        node._demand = (sum(wn.get_link(link_name).flow for link_name in wn.get_links_for_node(name, 'INLET')) -
                        sum(wn.get_link(link_name).flow for link_name in wn.get_links_for_node(name, 'OUTLET')))

--- a/wntr/sim/hydraulics.py
+++ b/wntr/sim/hydraulics.py
@@ -317,6 +317,7 @@ def store_results_in_network(wn, m):
     for name, link in wn.links():
         if link._is_isolated:
             link._flow = 0
+            link
         else:
             link._flow = m.flow[name].value
 

--- a/wntr/tests/test_models.py
+++ b/wntr/tests/test_models.py
@@ -107,7 +107,7 @@ class TestHeadloss(unittest.TestCase):
         m.head['j1'].value = j1_head
 
         for status in status_to_test:
-            pipe.status = status
+            pipe._user_status = status
             self.updater.update(m, wn, pipe, 'status')
             for f in flows_to_test:
                 m.flow['p1'].value = f
@@ -154,7 +154,7 @@ class TestHeadloss(unittest.TestCase):
             self.updater.update(m, wn, pump, 'pump_curve_name')
             A, B, C = pump.get_head_curve_coefficients()
             for status in status_to_test:
-                pump.status = status
+                pump._user_status = status
                 self.updater.update(m, wn, pump, 'status')
                 for f in flows_to_test:
                     m.flow['pump1'].value = f
@@ -199,7 +199,7 @@ class TestHeadloss(unittest.TestCase):
         m.head['j1'].value = j1_head
 
         for status in status_to_test:
-            pump.status = status
+            pump._user_status = status
             self.updater.update(m, wn, pump, 'status')
             for f in flows_to_test:
                 ff = float(f) # expr.m does not bind to

--- a/wntr/tests/test_network_controls.py
+++ b/wntr/tests/test_network_controls.py
@@ -254,8 +254,8 @@ class TestValveControls(unittest.TestCase):
         tank1_init_level = tank1.init_level
         tank1.init_level = tank2.init_level
         tank2.init_level = tank1_init_level
-        tank1.head = tank1.init_level + tank1.elevation
-        tank2.head = tank2.init_level + tank2.elevation
+        tank1._head = tank1.init_level + tank1.elevation
+        tank2._head = tank2.init_level + tank2.elevation
         for jname, j in wn.nodes(self.wntr.network.Junction):
             j.minimum_pressure = 0.0
             j.required_pressure = 15.0
@@ -321,7 +321,7 @@ class TestControlCombinations(unittest.TestCase):
         wn = self.wntr.network.WaterNetworkModel(inp_file)
         tank1 = wn.get_node('tank1')
         tank1.init_level = 40.0
-        tank1.head = tank1.elevation + 40.0
+        tank1._head = tank1.elevation + 40.0
         pipe1 = wn.get_link('pipe1')
         pipe1.status = self.wntr.network.LinkStatus.opened
         control_action = self.wntr.network.ControlAction(wn.get_link('pipe1'), 'status', self.wntr.network.LinkStatus.opened)
@@ -355,7 +355,7 @@ class TestControlCombinations(unittest.TestCase):
         wn = self.wntr.network.WaterNetworkModel(inp_file)
         tank1 = wn.get_node('tank1')
         tank1.init_level = 40.0
-        tank1.head = tank1.elevation + 40.0
+        tank1._head = tank1.elevation + 40.0
         pipe1 = wn.get_link('pipe1')
         pipe1.status = self.wntr.network.LinkStatus.opened
         control_action = self.wntr.network.ControlAction(wn.get_link('pipe1'), 'status', self.wntr.network.LinkStatus.opened)

--- a/wntr/tests/test_network_controls.py
+++ b/wntr/tests/test_network_controls.py
@@ -323,7 +323,7 @@ class TestControlCombinations(unittest.TestCase):
         tank1.init_level = 40.0
         tank1._head = tank1.elevation + 40.0
         pipe1 = wn.get_link('pipe1')
-        pipe1.status = self.wntr.network.LinkStatus.opened
+        pipe1._user_status = self.wntr.network.LinkStatus.opened
         control_action = self.wntr.network.ControlAction(wn.get_link('pipe1'), 'status', self.wntr.network.LinkStatus.opened)
         control = self.wntr.network.controls.Control._time_control(wn, 19*3600, 'SIM_TIME', False, control_action)
         wn.add_control('open_time_19',control)
@@ -357,7 +357,7 @@ class TestControlCombinations(unittest.TestCase):
         tank1.init_level = 40.0
         tank1._head = tank1.elevation + 40.0
         pipe1 = wn.get_link('pipe1')
-        pipe1.status = self.wntr.network.LinkStatus.opened
+        pipe1._user_status = self.wntr.network.LinkStatus.opened
         control_action = self.wntr.network.ControlAction(wn.get_link('pipe1'), 'status', self.wntr.network.LinkStatus.opened)
         control = self.wntr.network.controls.Control._time_control(wn, 5*3600, 'SIM_TIME', False, control_action)
         wn.add_control('open_time_5',control)

--- a/wntr/tests/test_sim_benchmark.py
+++ b/wntr/tests/test_sim_benchmark.py
@@ -167,7 +167,7 @@ class Test_Benchmarks(unittest.TestCase):
         wn.add_pipe("bypass_pump1","r1","j1",length=5.0,diameter=inp['d'])
         bypass_pump1 = wn.get_link("bypass_pump1")
         # this pipe is not open unless the pump closes.
-        bypass_pump1.status = 0
+        bypass_pump1._user_status = 0
         
         pump1 = wn.get_link("pump1")
         t1 = wn.get_node("t1")


### PR DESCRIPTION
Addresses bug #185 

Also changed:
- Making simulation values (outputs) non-writable and adding in missing ones (as compared to EPANET) into the classes.
- Also making internal properties private rather than public, and using setters/getters to handle protecting private attributes and doing type checking.
- changed results objects to use consistent names for links:
  - "reaction_rate" instead of "rxnrate" 
  - "quality" instead of "linkquality"
  - "friction_factor" instead of "frictionfact"