### PR TITLE
PUMP SPEED != 1

### DIFF
--- a/wntr/epanet/io.py
+++ b/wntr/epanet/io.py
@@ -778,7 +778,7 @@ class InpFile(object):
                 raise RuntimeError('Only head or power info is supported of pumps.')
             tmp_entry = _PUMP_ENTRY
             #if pump.speed_timeseries.base_value != 1:
-	    if pump.speed_timeseries.base_value is not None:
+            if pump.speed_timeseries.base_value is not None:
                 E['speed_keyword'] = 'SPEED'
                 E['speed'] = pump.speed_timeseries.base_value
                 tmp_entry = (tmp_entry.rstrip('\n').rstrip('}').rstrip('com:>3s').rstrip(' {') +

--- a/wntr/epanet/io.py
+++ b/wntr/epanet/io.py
@@ -777,7 +777,8 @@ class InpFile(object):
             else:
                 raise RuntimeError('Only head or power info is supported of pumps.')
             tmp_entry = _PUMP_ENTRY
-            if pump.speed_timeseries.base_value != 1:
+            #if pump.speed_timeseries.base_value != 1:
+	    if pump.speed_timeseries.base_value is not None:
                 E['speed_keyword'] = 'SPEED'
                 E['speed'] = pump.speed_timeseries.base_value
                 tmp_entry = (tmp_entry.rstrip('\n').rstrip('}').rstrip('com:>3s').rstrip(' {') +


### PR DESCRIPTION
When running a simulation with the Epanet Simulator the original INP file is copied into a temp.inp
If a pump has a setting SPEED of 1.0 this value is not passed to the temp.inp
The check of SPEED is made as "!= 1", however it must be if "is not None" 
** other checks must be passed SPEED is float or int, SPEED > 0