### PR TITLE
Variable pressure exponent

### DIFF
--- a/documentation/framework.rst
+++ b/documentation/framework.rst
@@ -164,7 +164,9 @@ Known discrepancies between the WNTRSimulator and EpanetSimulator are listed bel
   head pump curves are created by connecting the points with straight-line segments.  
   When using the WNTRSimulator, the points are fit to the same :math:`H = A - B*Q^C` 
   function that is used for 3-point curves.
-* **Variable minimum and required pressure**: 
-  While the WaterNetworkModel can store spatially variable minimum and required pressure that are used in the WNTRSimulator, 
-  those values cannot be saved when writing an INP file, rather the minimum and required pressure values in the options are saved.
-  This impacts the ability to use those junction attributes in the EpanetSimulator. 
+* **Variable required pressure, minimum pressure, and pressure exponent**: 
+  Junction attributes can be used to assign spatially variable required pressure, minimum pressure, and pressure exponent.  
+  These attributes are only used for pressure dependent demand simulation with the WNTRSimulator.  
+  If the junction attributes are set to None (the default value), then the required pressure, minimum pressure, and pressure exponent defined in the global hydraulic options (`wn.options.hydraulic`) are used for that junction.
+  Pressure dependent demand simulation using the EpanetSimulator always uses values in the global hydraulic options.
+ 

--- a/documentation/hydraulics.rst
+++ b/documentation/hydraulics.rst
@@ -269,7 +269,7 @@ in the following example.
     >>> wn.options.hydraulic.minimum_pressure = 0.55
 	
 When using the WNTRSimulator, the required pressure, minimum pressure, and pressure exponent can vary throughout the network.  
-By default, the each junction's required pressure, minimum pressure, and pressure exponent is set to None and the global value
+By default, each junction's required pressure, minimum pressure, and pressure exponent is set to None and the global value
 in the hydraulic options are used to define the PDD constraint for that junction. 
 If the user defines required pressure, minimum pressure, or pressure exponent on a junction, 
 those values will override the required pressure, minimum pressure, and pressure exponent defined in the global hydraulic options 
@@ -286,7 +286,7 @@ junction 121.
     
 The ability to use spatially variable required pressure, minimum pressure, and pressure 
 exponent is only available when using the WNTRSimulator.
-The EpanetSimulator always uses the global hydraulic options.
+The EpanetSimulator always uses values in the global hydraulic options.
 
 .. _leak_model:
 

--- a/documentation/hydraulics.rst
+++ b/documentation/hydraulics.rst
@@ -259,18 +259,22 @@ Using the pressure dependent demand simulation, the demand starts to decrease wh
    
    Relationship between pressure (p) and demand (d) using both the demand-driven and pressure dependent demand simulations.
 
-The required pressure and minimum pressure are defined in the the hydraulic options, and can be reset as shown 
+The required pressure, minimum pressure, and pressure exponent are defined in the global hydraulic options, and can be reset as shown 
 in the following example.
 
 .. doctest::
     
     >>> wn.options.hydraulic.required_pressure = 21.097 # 30 psi = 21.097 m
     >>> wn.options.hydraulic.minimum_pressure  = 3.516 # 5 psi = 3.516 m
+    >>> wn.options.hydraulic.minimum_pressure = 0.55
 	
-When using the WNTRSimultor, the required pressure and minimum pressure can vary throughout the network.  
-By default, the each junction's required and minimum pressure is set to None and the global value
-in the hydraulic options are used.  If the user defines required pressure or minimum pressure on a junction, 
-that value will override the global value.  The following example defines required pressure and minimum pressure on 
+When using the WNTRSimulator, the required pressure, minimum pressure, and pressure exponent can vary throughout the network.  
+By default, the each junction's required pressure, minimum pressure, and pressure exponent is set to None and the global value
+in the hydraulic options are used to define the PDD constraint for that junction. 
+If the user defines required pressure, minimum pressure, or pressure exponent on a junction, 
+those values will override the required pressure, minimum pressure, and pressure exponent defined in the global hydraulic options 
+when defining the PDD constraint for that junction.  
+The following example defines required pressure, minimum pressure, and pressure exponent on 
 junction 121.
 
 .. doctest::
@@ -278,6 +282,11 @@ junction 121.
     >>> junction = wn.get_node('121')
     >>> junction.required_pressure = 14.065 # 20 psi = 14.065 m
     >>> junction.minimum_pressure = 0.352 # 0.5 psi = 0.352 m												   
+    >>> junction.pressure_exponent = 0.4
+    
+The ability to use spatially variable required pressure, minimum pressure, and pressure 
+exponent is only available when using the WNTRSimulator.
+The EpanetSimulator always uses the global hydraulic options.
 
 .. _leak_model:
 

--- a/wntr/network/elements.py
+++ b/wntr/network/elements.py
@@ -81,6 +81,7 @@ class Junction(Node):
         elevation
         required_pressure
         minimum_pressure
+        pressure_exponent
         emitter_coefficient
         base_demand
         coordinates
@@ -107,6 +108,7 @@ class Junction(Node):
         self._elevation = 0.0
         self._required_pressure = None
         self._minimum_pressure = None
+        self._pressure_exponent = None
         self._emitter_coefficient = None
         self._leak = False
         self._leak_status = False
@@ -124,6 +126,7 @@ class Junction(Node):
         if abs(self.elevation - other.elevation)<1e-9 and \
            self.required_pressure == other.required_pressure and \
            self.minimum_pressure == other.minimum_pressure and \
+           self.pressure_exponent == other.pressure_exponent and \
            self.emitter_coefficient == other.emitter_coefficient:
             return True
         return False
@@ -165,6 +168,16 @@ class Junction(Node):
     def minimum_pressure(self, value):
         self._minimum_pressure = value
 
+    @property
+    def pressure_exponent(self):
+        """float: The pressure exponent attribute is used for pressure-dependent demand 
+        simulations. 
+        If set to None, the global value in wn.options.hydraulic.pressure_exponent is used."""
+        return self._minimum_pressure
+    @pressure_exponent.setter
+    def pressure_exponent(self, value):
+        self._pressure_exponent = value
+        
     @property
     def emitter_coefficient(self):
         """float : if not None, then activate an emitter with the specified coefficient"""

--- a/wntr/network/elements.py
+++ b/wntr/network/elements.py
@@ -173,7 +173,7 @@ class Junction(Node):
         """float: The pressure exponent attribute is used for pressure-dependent demand 
         simulations. 
         If set to None, the global value in wn.options.hydraulic.pressure_exponent is used."""
-        return self._minimum_pressure
+        return self._pressure_exponent
     @pressure_exponent.setter
     def pressure_exponent(self, value):
         self._pressure_exponent = value

--- a/wntr/sim/models/constraint.py
+++ b/wntr/sim/models/constraint.py
@@ -218,8 +218,7 @@ class pdd_constraint(Definition):
         index_over: list of str
             list of junction names; default is all junctions in wn
         """
-        pressure_exponent = wn.options.hydraulic.pressure_exponent
-        
+
         if not hasattr(m, 'pdd'):
             m.pdd = aml.ConstraintDict()
 
@@ -234,7 +233,12 @@ class pdd_constraint(Definition):
             h = m.head[node_name]
             d = m.demand[node_name]
             d_expected = m.expected_demand[node_name]
-
+            
+            if node.pressure_exponent is None:
+                pressure_exponent = wn.options.hydraulic.pressure_exponent
+            else:
+                pressure_exponent = node.pressure_exponent
+                
             if not node._is_isolated:
                 pmin = m.pmin[node_name]
                 pnom = m.pnom[node_name]


### PR DESCRIPTION
This PR adds the ability to define pressure exponent as a junction attribute.  The attribute is only used for pressure dependent demand simulation with the WNTRSimulator and allows the pressure exponent vary throughout the network.  If the attribute is defined as None (the default value), the global options are used for that junction. Pressure dependent demand simulation using the EpanetSimulator always uses values in the global options.  This follows the same convention already used for required pressure and minimum pressure.