### PR TITLE
Bug fix for plotting directed networks with link attributes

### DIFF
--- a/wntr/graphics/network.py
+++ b/wntr/graphics/network.py
@@ -228,8 +228,16 @@ def plot_network(wn, node_attribute=None, link_attribute=None, title=None,
         clb = plt.colorbar(nodes, shrink=0.5, pad=0, ax=ax)
         clb.ax.set_title(node_colorbar_label, fontsize=10)
     if add_link_colorbar and link_attribute:
-        clb = plt.colorbar(edges, shrink=0.5, pad=0.05, ax=ax)
+        if directed:
+            vmin = min(map(abs,link_attribute.values()))
+            vmax = max(map(abs,link_attribute.values())) 
+            sm = plt.cm.ScalarMappable(cmap=link_cmap, norm=plt.Normalize(vmin=vmin, vmax=vmax))
+            sm.set_array([])
+            clb = plt.colorbar(sm, shrink=0.5, pad=0.05, ax=ax)
+        else:
+            clb = plt.colorbar(edges, shrink=0.5, pad=0.05, ax=ax)
         clb.ax.set_title(link_colorbar_label, fontsize=10)
+        
     ax.axis('off')
     
     if filename:

--- a/wntr/tests/test_graphics.py
+++ b/wntr/tests/test_graphics.py
@@ -83,6 +83,27 @@ def test_plot_network5():
     plt.close()
     
     assert_true(isfile(filename))
+
+def test_plot_network6():
+    filename = abspath(join(testdir, 'plot_network6.png'))
+    if isfile(filename):
+        os.remove(filename)
+
+    inp_file = join(ex_datadir,'Net3.inp')
+    wn = wntr.network.WaterNetworkModel(inp_file)
+    sim = wntr.sim.EpanetSimulator(wn)
+    results = sim.run_sim()
+    flowrate_at_5hr = results.link['flowrate'].loc[5*3600, :]*100
+
+    plt.figure(figsize=(15,10))
+    ax = plt.gca()
+    wntr.graphics.plot_network(wn, node_attribute='elevation', link_attribute=flowrate_at_5hr, 
+                               node_size=7, directed=True, node_colorbar_label='Elevation', 
+                               link_colorbar_label='Flowrate', ax=ax)
+    plt.savefig(filename, format='png')
+    plt.close()
+    
+    assert_true(isfile(filename))
     
 def test_plot_interactive_network1():
     
@@ -196,4 +217,5 @@ def test_custom_colormap():
 if __name__ == '__main__':
     test_network_animation1()
     test_plot_tank_curve()
+    test_plot_network6()
     


### PR DESCRIPTION
This PR fixes an error in `plot_network` related to #205 