### PR TITLE
Update io.py

### DIFF
--- a/wntr/epanet/io.py
+++ b/wntr/epanet/io.py
@@ -1911,9 +1911,9 @@ class InpFile(object):
                     logger.warning('Unknown report parameter: %s', current[0])
                     continue
                 elif current[1].upper() in ['YES']:
-                    self.wn.options.report.report_params[current[0].lower()][1] = True
+                    self.wn.options.report.report_params[current[0].lower()] = True
                 elif current[1].upper() in ['NO']:
-                    self.wn.options.report.report_params[current[0].lower()][1] = False
+                    self.wn.options.report.report_params[current[0].lower()] = False
                 else:
                     self.wn.options.report.param_opts[current[0].lower()][current[1].upper()] = float(current[2])
 


### PR DESCRIPTION
`wn.options.report.report_params` is a dictionary with boolean values.
Using `[1]` is trying to insert value according to index and error is raised:
`TypeError: 'bool' object does not support item assignment`