### PR TITLE
Added pattern start to the WNTRSimulator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,9 +12,9 @@ wntr.egg-info/
 *.pickle
 *.xlsx
 
-temp.inp
-temp.bin
-temp.rpt
+temp*.inp
+temp*.bin
+temp*.rpt
 
 examples/*.inp
 wntr/tests/*.png

--- a/documentation/framework.rst
+++ b/documentation/framework.rst
@@ -142,7 +142,7 @@ Of the EPANET model options that directly apply to hydraulic simulations, **the 
 * D-W and C-M headloss options in the [OPTIONS] section (H-W option is used)
 * Accuracy, unbalanced, and emitter exponent from the [OPTIONS] section
 * Pump speed in the [PUMPS] section
-* Pattern start, report start, and statistics in the [TIMES] section
+* Report start and statistics in the [TIMES] section
 * PBV and GPV values in the [VALVES] section
 
 **Future development of WNTR will address these limitations.**

--- a/documentation/users.rst
+++ b/documentation/users.rst
@@ -16,6 +16,8 @@ Related software
 
 * CriticalityMaps: https://github.com/pshassett/CriticalityMaps
 
+* Digital HydrAuLic SIMulator (DHALSIM): https://github.com/afmurillo/DHALSIM
+
 * LeakDB: https://github.com/KIOS-Research/LeakDB
 
 * PPMTools: https://github.com/USEPA/PPMtools
@@ -29,11 +31,13 @@ Publications
 
 * Abdel-Mottaleb, N., Ghasemi Saghand, P., Charkhgard, H., & Zhang, Q. (2019). An exact multiobjective optimization approach for evaluating water distribution infrastructure criticality and geospatial interdependence. Water Resources Research, 55(7), 5255-5276.
 
-* Antonowicz, A., Bałut, A., Urbaniak, A., & Zakrzewski, P. (2019, May). Algorithm for Early Warning System for Contamination in Water Network. In 2019 20th International Carpathian Control Conference (ICCC) (pp. 1-5). IEEE.
+* Antonowicz, A., Bałut, A., Urbaniak, A., & Zakrzewski, P. (2019). Algorithm for Early Warning System for Contamination in Water Network. In 2019 20th International Carpathian Control Conference (ICCC) (pp. 1-5). IEEE.
 
 * Bjerke, M. (2019). Leak Detection in Water Distribution Networks using Gated Recurrent Neural Networks, Master's thesis, Norwegian University of Science and Technology (NTNU)
 
 * Bunn, B. B. (2018). An operational model of interdependent water and power distribution infrastructure systems. Naval Postgraduate School, Monterey, CA
+
+* Fan, X., Zhang, X., & Yu, X. B. (2021). Machine learning model and strategy for fast and accurate detection of leaks in water supply network. Journal of Infrastructure Preservation and Resilience, 2(1), 1-21.
 
 * Han, Q., Eguchi, R., Mehrotra, S., & Venkatasubramanian, N. (2018). Enabling state estimation for fault identification in water distribution systems under large disasters. In 2018 IEEE 37th Symposium on Reliable Distributed Systems (SRDS) (pp. 161-170). IEEE.
 
@@ -41,13 +45,27 @@ Publications
 
 * Liu, Y., Barrows, C., Macknick, J., & Mauter, M. (2020). Optimization Framework to Assess the Demand Response Capacity of a Water Distribution System. Journal of Water Resources Planning and Management, 146(8), 04020063.
 
-* MMazumder, R. K., Salman, A. M., Li, Y., & Yu, X. (2019). A Decision-making Framework for Water Distribution Systems using Fuzzy Inference and Centrality Analysis. 13th International Conference on Applications of Statistics and Probability in Civil Engineering, ICASP13, Seoul, South Korea, May 26-30, 2019
+* Logan, K. T., Lestakova, M., Thiessen, N., Engels, J. I., & Pelz, P. F. (2021). Water Distribution in a Socio-Technical System: Resilience Assessment for Critical Events Causing Demand Relocation. Water, 13(15), 2062.
+
+* Lorenz, I. S., & Pelz, P. F. (2020). Optimal resilience enhancement of water distribution systems. Water, 12(9), 2602.
+
+* Mazumder, R. K., Salman, A. M., Li, Y., & Yu, X. (2019). A Decision-making Framework for Water Distribution Systems using Fuzzy Inference and Centrality Analysis. 13th International Conference on Applications of Statistics and Probability in Civil Engineering, ICASP13, Seoul, South Korea, May 26-30, 2019
+
+* Mazumder, R. K., Salman, A. M., & Li, Y. (2020). Post-disaster sequential recovery planning for water distribution systems using topological and hydraulic metrics. Structure and Infrastructure Engineering, 1-16.
+
+* Murillo, A., Taormina, R., Tippenhauer, N., & Galelli, S. (2020). Co-Simulating Physical Processes and Network Data for High-Fidelity Cyber-Security Experiments. In Sixth Annual Industrial Control System Security (ICSS) Workshop (pp. 13-20).
 
 * Nikolopoulos, D., Moraitis, G., Bouziotas, D., Lykou, A., Karavokiros, G., & Makropoulos, C. (2020). Cyber-physical stress-testing platform for water distribution networks. Journal of Environmental Engineering, 146(7), 04020061.
+
+* Nikolopoulos, D., Ostfeld, A., Salomons, E., & Makropoulos, C. (2021). Resilience Assessment of Water Quality Sensor Designs under Cyber-Physical Attacks. Water, 13(5), 647.
+
+* Nyahora, P. P., Babel, M. S., Ferras, D., & Emen, A. (2020). Multi-objective optimization for improving equity and reliability in intermittent water supply systems. Water Supply, 20(5), 1592-1603.
 
 * Pagani, A., Wei, Z., Silva, R., & Guo, W. (2020). Neural Network Approximation of Graph Fourier Transforms for Sparse Sampling of Networked Flow Dynamics. arXiv preprint arXiv:2002.05508.
 
 * Sharma, N., Tabandeh, A., & Gardoni, P. (2019). Recovery optimization of interdependent infrastructure: a multi-scale approach. 13th International Conference on Applications of Statistics and Probability in Civil Engineering, ICASP13
+
+* Sharma, N., Tabandeh, A., & Gardoni, P. (2020). Regional resilience analysis: A multiscale approach to optimize the resilience of interdependent infrastructure. Computer‐Aided Civil and Infrastructure Engineering, 35(12), 1315-1330.
 
 * Tabandeh, S. (2018). Societal risk and resilience analysis: A multi-scale approach to model the dynamics of infrastructure-social systems (Doctoral dissertation, University of Illinois at Urbana-Champaign).
 
@@ -56,5 +74,7 @@ Publications
 * Vrachimis, S. G., & Kyriakou, M. S. (2018). LeakDB: A benchmark dataset for leakage diagnosis in water distribution networks. In WDSA/CCWI Joint Conference Proceedings (Vol. 1).
 
 * Vrachimis, S. G., Eliades, D. G., & Polycarpou, M. M. (2018). Leak detection in water distribution systems using hydraulic interval state estimation. In 2018 IEEE Conference on Control Technology and Applications (CCTA) (pp. 565-570). IEEE.
+
+* Wille, D. (2019). Simulation-optimization for operational resilience of interdependent water-power systems in the US Virgin Islands (Doctoral dissertation, Monterey, CA; Naval Postgraduate School).
 
 * Xing, L., & Sela, L. (2020). Transient simulations in water distribution networks: TSNet python package. Advances in Engineering Software, 149, 102884.

--- a/documentation/whatsnew.rst
+++ b/documentation/whatsnew.rst
@@ -1,7 +1,7 @@
 Release notes
 ================
 
-.. include:: whatsnew/v0.3.2.rst
+.. include:: whatsnew/v0.4.0.rst
 
 .. include:: whatsnew/v0.3.1.rst
 

--- a/documentation/whatsnew.rst
+++ b/documentation/whatsnew.rst
@@ -1,6 +1,8 @@
 Release notes
 ================
 
+.. include:: whatsnew/v0.4.1.rst
+
 .. include:: whatsnew/v0.4.0.rst
 
 .. include:: whatsnew/v0.3.1.rst

--- a/documentation/whatsnew/v0.4.0.rst
+++ b/documentation/whatsnew/v0.4.0.rst
@@ -42,8 +42,6 @@ v0.4.0 (August 26, 2021)
   If the user sets a lower limit below 0.1 m, the value of 0.1 m is used in the INP file and a warning is issued.
   Note, the lower limit is also the default value in EPANET (and therefore the default for ``wn.options.hydraulic.required_pressure``).
 
-* Bug fix for private attribute associated with power outage controls.
-
 * Updated documentation example that creates a weighted graph.
 
 * Updated all tests to use unittest. Removed Travis CI testing framework, all tests are run through GitHub Actions.

--- a/documentation/whatsnew/v0.4.0.rst
+++ b/documentation/whatsnew/v0.4.0.rst
@@ -1,6 +1,6 @@
-.. _whatsnew_032:
+.. _whatsnew_040:
 
-v0.3.2 (main branch)
+v0.4.0 (main branch)
 ---------------------------------------------------
 
 * Changed the following network component attributes:
@@ -30,7 +30,7 @@ v0.3.2 (main branch)
 
 * Updated the WNTRSimulator link results to include ``setting``.
 
-* Updated the WNTRSimulator to use `wn.options.time.start_clocktime`.
+* Updated the WNTRSimulator to use ``wn.options.time.start_clocktime`` and ``wn.options.time.pattern_start``.
 
 * Updated Net 1, Net 2, and Net 3 network model files to match EPANET versions.  
   The network files were updated to include a tank overflow entry and 3 digit coordinates.
@@ -41,6 +41,8 @@ v0.3.2 (main branch)
 * Bug fix to enforce EPANET lower limit for required pressure (0.1 in psi or m).  
   If the user sets a lower limit below 0.1 m, the value of 0.1 m is used in the INP file and a warning is issued.
   Note, the lower limit is also the default value in EPANET (and therefore the default for ``wn.options.hydraulic.required_pressure``).
+
+* Bug fix for private attribute associated with power outage controls.
 
 * Updated documentation example that creates a weighted graph.
 

--- a/documentation/whatsnew/v0.4.1.rst
+++ b/documentation/whatsnew/v0.4.1.rst
@@ -4,3 +4,5 @@ v0.4.1 (main)
 ---------------------------------------------------
 
 * Updated the WNTRSimulator to use ``wn.options.time.pattern_start``.
+
+* Removed private attribute on pumps associated with power outage controls which is no longer needed.

--- a/documentation/whatsnew/v0.4.1.rst
+++ b/documentation/whatsnew/v0.4.1.rst
@@ -1,0 +1,6 @@
+.. _whatsnew_041:
+
+v0.4.1 (main)
+---------------------------------------------------
+
+* Updated the WNTRSimulator to use ``wn.options.time.pattern_start``.

--- a/wntr/__init__.py
+++ b/wntr/__init__.py
@@ -7,7 +7,7 @@ from wntr import scenario
 from wntr import graphics
 from wntr import utils
 
-__version__ = '0.3.2'
+__version__ = '0.4.0'
 
 __copyright__ = """Copyright 2019 National Technology & Engineering 
 Solutions of Sandia, LLC (NTESS). Under the terms of Contract DE-NA0003525 

--- a/wntr/__init__.py
+++ b/wntr/__init__.py
@@ -7,7 +7,7 @@ from wntr import scenario
 from wntr import graphics
 from wntr import utils
 
-__version__ = '0.4.0'
+__version__ = '0.4.1'
 
 __copyright__ = """Copyright 2019 National Technology & Engineering 
 Solutions of Sandia, LLC (NTESS). Under the terms of Contract DE-NA0003525 

--- a/wntr/network/elements.py
+++ b/wntr/network/elements.py
@@ -1112,7 +1112,7 @@ class Pump(Link):
         """
         from wntr.network.controls import ControlAction, SimTimeCondition, AndCondition, Rule
         
-        self._power_outage = True
+        self._power_outage = LinkStatus.Closed
         
         # Outage
         act = ControlAction(self, 'status', LinkStatus.Closed)
@@ -1141,7 +1141,7 @@ class Pump(Link):
         wn : :class:`~wntr.network.model.WaterNetworkModel`
            Water network model
         """
-        self._power_outage = False
+        self._power_outage = LinkStatus.Open
         
         wn._discard_control(self._outage_rule_name)
         wn._discard_control(self._after_outage_rule_name)

--- a/wntr/network/elements.py
+++ b/wntr/network/elements.py
@@ -1015,7 +1015,6 @@ class Pump(Link):
         self._efficiency = None
         self._energy_price = None 
         self._energy_pattern = None
-        self._power_outage = LinkStatus.Open
         self._outage_rule_name = name+'_outage'
         self._after_outage_rule_name = name+'_after_outage'
 
@@ -1052,8 +1051,6 @@ class Pump(Link):
     def status(self):
         """LinkStatus : the current status of the pump"""
         if self._internal_status == LinkStatus.Closed:
-            return LinkStatus.Closed
-        elif self._power_outage == LinkStatus.Closed:
             return LinkStatus.Closed
         else:
             return self._user_status
@@ -1111,9 +1108,7 @@ class Pump(Link):
             For example, the pump opens based on the level of a specific tank.
         """
         from wntr.network.controls import ControlAction, SimTimeCondition, AndCondition, Rule
-        
-        self._power_outage = LinkStatus.Closed
-        
+
         # Outage
         act = ControlAction(self, 'status', LinkStatus.Closed)
         cond1 = SimTimeCondition(wn, 'Above' , start_time)
@@ -1141,7 +1136,6 @@ class Pump(Link):
         wn : :class:`~wntr.network.model.WaterNetworkModel`
            Water network model
         """
-        self._power_outage = LinkStatus.Open
         
         wn._discard_control(self._outage_rule_name)
         wn._discard_control(self._after_outage_rule_name)

--- a/wntr/network/model.py
+++ b/wntr/network/model.py
@@ -1419,7 +1419,6 @@ class WaterNetworkModel(AbstractModel):
             link._flow = None
             if isinstance(link, PowerPump):
                 link.power = link._base_power
-            link._power_outage = LinkStatus.Open
             link._prev_setting = None
 
         for name, link in self.links(Valve):

--- a/wntr/sim/models/param.py
+++ b/wntr/sim/models/param.py
@@ -42,14 +42,16 @@ def expected_demand_param(m, wn):
     wn: wntr.network.model.WaterNetworkModel
     """
     demand_multiplier = wn.options.hydraulic.demand_multiplier
+    pattern_start = wn.options.time.pattern_start
+    
     if not hasattr(m, 'expected_demand'):
         m.expected_demand = aml.ParamDict()
 
         for node_name, node in wn.junctions():
-            m.expected_demand[node_name] = aml.Param(node.demand_timeseries_list.at(wn.sim_time, multiplier=demand_multiplier))
+            m.expected_demand[node_name] = aml.Param(node.demand_timeseries_list.at(wn.sim_time+pattern_start, multiplier=demand_multiplier))
     else:
         for node_name, node in wn.junctions():
-            m.expected_demand[node_name].value = node.demand_timeseries_list.at(wn.sim_time, multiplier=demand_multiplier)
+            m.expected_demand[node_name].value = node.demand_timeseries_list.at(wn.sim_time+pattern_start, multiplier=demand_multiplier)
 
 
 class pmin_param(Definition):

--- a/wntr/sim/models/var.py
+++ b/wntr/sim/models/var.py
@@ -22,9 +22,11 @@ def demand_var(m, wn, index_over=None):
         index_over = wn.junction_name_list
 
     demand_multiplier = wn.options.hydraulic.demand_multiplier
+    pattern_start = wn.options.time.pattern_start
+    
     for node_name in index_over:
         node = wn.get_node(node_name)
-        m.demand[node_name] = aml.Var(node.demand_timeseries_list.at(wn.sim_time, multiplier=demand_multiplier))
+        m.demand[node_name] = aml.Var(node.demand_timeseries_list.at(wn.sim_time+pattern_start, multiplier=demand_multiplier))
 
 
 def flow_var(m, wn, index_over=None):

--- a/wntr/tests/test_epanet_toolkit.py
+++ b/wntr/tests/test_epanet_toolkit.py
@@ -54,16 +54,16 @@ class TestEpanetToolkit(unittest.TestCase):
         enData.inpfile = join(datadir, "Net1.inp")
         enData.ENopen(enData.inpfile, "temp.rpt")
         
-        enData.ENsaveinpfile("Net1_toolkit.inp") 
-        file_exists = exists("Net1_toolkit.inp")
+        enData.ENsaveinpfile("temp_Net1_toolkit.inp") 
+        file_exists = exists("temp_Net1_toolkit.inp")
         assert file_exists
         
     def test_runepanet(self):
         inpfile = join(datadir, "Net1.inp")
-        wntr.epanet.toolkit.runepanet(inpfile, "test_runepanet.rpt", "test_runepanet.bin")
+        wntr.epanet.toolkit.runepanet(inpfile, "temp_runepanet.rpt", "temp_runepanet.bin")
                  
         reader = wntr.epanet.io.BinFile()
-        results = reader.read("test_runepanet.bin")
+        results = reader.read("temp_runepanet.bin")
         
         assert(isinstance(results, wntr.sim.results.SimulationResults))
         assert(results.node['pressure'].shape == (25,11))
@@ -71,7 +71,7 @@ class TestEpanetToolkit(unittest.TestCase):
     def test_runepanet_step(self):
         enData = wntr.epanet.toolkit.ENepanet()
         enData.inpfile = join(datadir, "Net1.inp")
-        enData.ENopen(enData.inpfile, "test_runepanet_step.rpt", "test_runepanet_step.bin")
+        enData.ENopen(enData.inpfile, "temp_runepanet_step.rpt", "temp_runepanet_step.bin")
         
         enData.ENopenH()
         enData.ENinitH(0)

--- a/wntr/tests/test_sim_reset_conditions.py
+++ b/wntr/tests/test_sim_reset_conditions.py
@@ -72,7 +72,7 @@ class Test_Reset_Conditions(unittest.TestCase):
             results2.node["pressure"].plot(ax=ax)
 
             wn.options.time.duration = 100 * 3600
-            wn.write_inpfile("Net3_epanet.inp")
+            wn.write_inpfile("temp_Net3_epanet.inp")
 
             results3 = sim.run_sim()
             results3.node["pressure"].plot(ax=ax, title="WNTRSim_continue")


### PR DESCRIPTION
The following PR adds the ability to use a pattern start time with the WNTRSimulator.  This PR also removes a private attribute from pumps that is no longer needed to model power outages, updates the user community webpage, and renamed some files created in tests.