### PR TITLE
Added ability to easily update Control/Rule parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ wntr.egg-info/
 temp*.inp
 temp*.bin
 temp*.rpt
+temp*.json
 
 examples/*.inp
 wntr/tests/*.png

--- a/wntr/network/controls.py
+++ b/wntr/network/controls.py
@@ -2135,14 +2135,7 @@ class Control(Rule):
         name: str
             The name of the control
         """
-        self._condition = condition
-        self._then_actions = [then_action]
-        self._else_actions = []
-        self._which = None
-        self._priority = priority
-        self._name = name
-        if self._name is None:
-            self._name = ''
+        super().__init__(condition=condition, then_actions=then_action, priority=priority, name=name)
         if isinstance(condition, TankLevelCondition):
             self._control_type = _ControlType.pre_and_postsolve
         elif isinstance(condition, (TimeOfDayCondition, SimTimeCondition)):

--- a/wntr/network/controls.py
+++ b/wntr/network/controls.py
@@ -2103,54 +2103,55 @@ class Rule(ControlBase):
         else:
             raise RuntimeError('control actions called even though if-then statement was False')
     
-    def update_condition(self, condition, verbose = False):
-        """Update the controls condition in place"""
-        if verbose:
-            try:
-                logger.info(f"Replacing {self._condition} with {condition}")
-            except AttributeError:
-                # self._condition doesn't already exist. Not sure how we could get here, 
-                # but best to make sure it doesn't error out.
-                pass
+    def update_condition(self, condition:ControlCondition):
+        """Update the controls condition in place
 
+        Parameters
+        ----------
+        condition : ControlCondition
+            The new condition for this control to use
+
+        Raises
+        ------
+        ValueError
+            If the provided condition isn't a valid ControlCondition
+        """
+        logger.info(f"Replacing {self._condition} with {condition}")
         if not isinstance(condition, ControlCondition):
             raise ValueError('The conditions argument must be a ControlCondition instance')
         self._condition = condition
 
-    def update_then_actions(self, then_actions, verbose=False):
-        """Update the rule's then actions in place"""
-        if verbose:
-            try:
-                logger.info(f"Replacing {self._then_actions} with {then_actions}")
-            except AttributeError:
-                # self._then_actions doesn't already exist. Not sure how we could get here, 
-                # but best to make sure it doesn't error out.
-                pass
-        
+    def update_then_actions(self, then_actions:Iterable[ControlAction]):
+        """Update the controls then_actions in place
+
+        Parameters
+        ----------
+        then_actions : Iterable[ControlAction]
+            The new then_actions for this control to use
+        """        
+        logger.info(f"Replacing {self._then_actions} with {then_actions}")        
         self._then_actions = _ensure_iterable(then_actions)
 
-    def update_else_actions(self, else_actions, verbose=False):
-        """Update the rule's else actions in place"""
-        if verbose:
-            try:
-                logger.info(f"Replacing {self._else_actions} with {else_actions}")
-            except AttributeError:
-                # self._else_actions doesn't already exist. Not sure how we could get here, 
-                # but best to make sure it doesn't error out.
-                pass
+    def update_else_actions(self, else_actions:Iterable[ControlAction]):
+        """Update the controls else_actions in place
 
+        Parameters
+        ----------
+        else_actions : Iterable[ControlAction]
+            The new else_actions for this control to use
+        """
+        logger.info(f"Replacing {self._else_actions} with {else_actions}")
         self._else_actions = _ensure_iterable(else_actions)
     
-    def update_priority(self, priority, verbose=False):
-        """Update the rule's priority in place"""
-        if verbose:
-            try:
-                logger.info(f"Replacing {self._priority} with {priority}")
-            except AttributeError:
-                # self._priority doesn't already exist. Not sure how we could get here, 
-                # but best to make sure it doesn't error out.
-                pass
+    def update_priority(self, priority:ControlPriority):
+        """Update the controls priority in place
 
+        Parameters
+        ----------
+        priority : ControlPriority
+            The new priority for this control to use
+        """
+        logger.info(f"Replacing {self._priority} with {priority}")
         self._priority = priority
 
 

--- a/wntr/network/controls.py
+++ b/wntr/network/controls.py
@@ -2109,7 +2109,8 @@ class Rule(ControlBase):
             try:
                 logger.info(f"Replacing {self._condition} with {condition}")
             except AttributeError:
-                # self._condition doesn't already exist
+                # self._condition doesn't already exist. Not sure how we could get here, 
+                # but best to make sure it doesn't error out.
                 pass
 
         if not isinstance(condition, ControlCondition):
@@ -2122,7 +2123,8 @@ class Rule(ControlBase):
             try:
                 logger.info(f"Replacing {self._then_actions} with {then_actions}")
             except AttributeError:
-                # self._then_actions doesn't already exist
+                # self._then_actions doesn't already exist. Not sure how we could get here, 
+                # but best to make sure it doesn't error out.
                 pass
         
         self._then_actions = _ensure_iterable(then_actions)
@@ -2133,7 +2135,8 @@ class Rule(ControlBase):
             try:
                 logger.info(f"Replacing {self._else_actions} with {else_actions}")
             except AttributeError:
-                # self._else_actions doesn't already exist
+                # self._else_actions doesn't already exist. Not sure how we could get here, 
+                # but best to make sure it doesn't error out.
                 pass
 
         self._else_actions = _ensure_iterable(else_actions)
@@ -2144,7 +2147,8 @@ class Rule(ControlBase):
             try:
                 logger.info(f"Replacing {self._priority} with {priority}")
             except AttributeError:
-                # self._priority doesn't already exist
+                # self._priority doesn't already exist. Not sure how we could get here, 
+                # but best to make sure it doesn't error out.
                 pass
 
         self._priority = priority

--- a/wntr/network/controls.py
+++ b/wntr/network/controls.py
@@ -35,11 +35,10 @@ from .elements import LinkStatus
 import abc
 from wntr.utils.ordered_set import OrderedSet
 from collections import OrderedDict
-from collections.abc import Iterable
 from .elements import Tank, Junction, Valve, Pump, Reservoir, Pipe
 from wntr.utils.doc_inheritor import DocInheritor
 import warnings
-from typing import Hashable, Dict, Any, Tuple, MutableSet
+from typing import Hashable, Dict, Any, Tuple, MutableSet, Iterable
 
 logger = logging.getLogger(__name__)
 
@@ -71,6 +70,26 @@ logger = logging.getLogger(__name__)
 #    Close check valves/pumps for negative flow
 #    Close pumps without power
 
+def _ensure_iterable(to_check: Any)->Iterable[Any]:
+    """Make sure the input is interable
+
+    Parameters
+    ----------
+    to_check : Any
+        The input to check which can be of any type including None
+
+    Returns
+    -------
+    Iterable[Any]
+        to_check as an iterable object, if None an empty list is returned
+    """
+    if isinstance(to_check, Iterable):
+        to_return = list(to_check)
+    elif to_check is not None:
+        to_return = [to_check]
+    else:
+        to_return = []
+    return to_return
 
 class Subject(object):
     """

--- a/wntr/network/controls.py
+++ b/wntr/network/controls.py
@@ -2116,7 +2116,11 @@ class Rule(ControlBase):
         ValueError
             If the provided condition isn't a valid ControlCondition
         """
-        logger.info(f"Replacing {self._condition} with {condition}")
+        try:
+            logger.info(f"Replacing {self._condition} with {condition}")
+        except AttributeError:
+            # Occurs during intialisation
+            pass
         if not isinstance(condition, ControlCondition):
             raise ValueError('The conditions argument must be a ControlCondition instance')
         self._condition = condition
@@ -2129,7 +2133,11 @@ class Rule(ControlBase):
         then_actions : Iterable[ControlAction]
             The new then_actions for this control to use
         """        
-        logger.info(f"Replacing {self._then_actions} with {then_actions}")        
+        try:
+            logger.info(f"Replacing {self._then_actions} with {then_actions}")        
+        except AttributeError:
+            # Occurs during intialisation
+            pass
         self._then_actions = _ensure_iterable(then_actions)
 
     def update_else_actions(self, else_actions:Iterable[ControlAction]):
@@ -2140,7 +2148,11 @@ class Rule(ControlBase):
         else_actions : Iterable[ControlAction]
             The new else_actions for this control to use
         """
-        logger.info(f"Replacing {self._else_actions} with {else_actions}")
+        try:
+            logger.info(f"Replacing {self._else_actions} with {else_actions}")
+        except AttributeError:
+            # Occurs during intialisation
+            pass
         self._else_actions = _ensure_iterable(else_actions)
     
     def update_priority(self, priority:ControlPriority):
@@ -2151,7 +2163,11 @@ class Rule(ControlBase):
         priority : ControlPriority
             The new priority for this control to use
         """
-        logger.info(f"Replacing {self._priority} with {priority}")
+        try:
+            logger.info(f"Replacing {self._priority} with {priority}")
+        except AttributeError:
+            # Occurs during intialisation
+            pass
         self._priority = priority
 
 

--- a/wntr/network/controls.py
+++ b/wntr/network/controls.py
@@ -1993,23 +1993,11 @@ class Rule(ControlBase):
         name: str
             The name of the control
         """
-        if not isinstance(condition, ControlCondition):
-            raise ValueError('The conditions argument must be a ControlCondition instance')
-        self._condition = condition
-        if isinstance(then_actions, Iterable):
-            self._then_actions = list(then_actions)
-        elif then_actions is not None:
-            self._then_actions = [then_actions]
-        else:
-            self._then_actions = []
-        if isinstance(else_actions, Iterable):
-            self._else_actions = list(else_actions)
-        elif else_actions is not None:
-            self._else_actions = [else_actions]
-        else:
-            self._else_actions = []
+        self.update_condition(condition)
+        self.update_then_actions(then_actions)
+        self.update_else_actions(else_actions)
         self._which = None
-        self._priority = priority
+        self.update_priority(priority)
         self._name = name
         if self._name is None:
             self._name = ''
@@ -2114,6 +2102,52 @@ class Rule(ControlBase):
                 control_action.run_control_action()
         else:
             raise RuntimeError('control actions called even though if-then statement was False')
+    
+    def update_condition(self, condition, verbose = False):
+        """Update the controls condition in place"""
+        if verbose:
+            try:
+                logger.info(f"Replacing {self._condition} with {condition}")
+            except AttributeError:
+                # self._condition doesn't already exist
+                pass
+
+        if not isinstance(condition, ControlCondition):
+            raise ValueError('The conditions argument must be a ControlCondition instance')
+        self._condition = condition
+
+    def update_then_actions(self, then_actions, verbose=False):
+        """Update the rule's then actions in place"""
+        if verbose:
+            try:
+                logger.info(f"Replacing {self._then_actions} with {then_actions}")
+            except AttributeError:
+                # self._then_actions doesn't already exist
+                pass
+        
+        self._then_actions = _ensure_iterable(then_actions)
+
+    def update_else_actions(self, else_actions, verbose=False):
+        """Update the rule's else actions in place"""
+        if verbose:
+            try:
+                logger.info(f"Replacing {self._else_actions} with {else_actions}")
+            except AttributeError:
+                # self._else_actions doesn't already exist
+                pass
+
+        self._else_actions = _ensure_iterable(else_actions)
+    
+    def update_priority(self, priority, verbose=False):
+        """Update the rule's priority in place"""
+        if verbose:
+            try:
+                logger.info(f"Replacing {self._priority} with {priority}")
+            except AttributeError:
+                # self._priority doesn't already exist
+                pass
+
+        self._priority = priority
 
 
 class Control(Rule):

--- a/wntr/tests/test_network_controls.py
+++ b/wntr/tests/test_network_controls.py
@@ -167,7 +167,7 @@ class TestConditionalControls(unittest.TestCase):
         # check current priority is different to the new one
         self.assertNotEqual(wn.get_control(wn.control_name_list[idx]).priority, new_priority)
         # Update priority and check it has worked
-        wn.get_control(wn.control_name_list[idx]).update_priority(new_priority, verbose=True)
+        wn.get_control(wn.control_name_list[idx]).update_priority(new_priority)
         self.assertEqual(wn.get_control(wn.control_name_list[idx]).priority, new_priority)
 
     def test_update_conditions(self):
@@ -177,7 +177,7 @@ class TestConditionalControls(unittest.TestCase):
         new_condition = self.wntr.network.controls.TimeOfDayCondition(wn, 'Is','01:00:00')
 
         self.assertNotEqual(wn.get_control(wn.control_name_list[idx]).condition, new_condition)
-        wn.get_control(wn.control_name_list[idx]).update_condition(new_condition, verbose=True)
+        wn.get_control(wn.control_name_list[idx]).update_condition(new_condition)
         self.assertEqual(wn.get_control(wn.control_name_list[idx]).condition, new_condition)
 
 
@@ -192,7 +192,7 @@ class TestConditionalControls(unittest.TestCase):
         iterable_action = self.wntr.network.controls._ensure_iterable(new_action)
 
         self.assertNotEqual(wn.get_control(wn.control_name_list[0])._then_actions,iterable_action)
-        wn.get_control(wn.control_name_list[0]).update_then_actions(new_action, verbose=True)
+        wn.get_control(wn.control_name_list[0]).update_then_actions(new_action)
         self.assertEqual(wn.get_control(wn.control_name_list[0])._then_actions,iterable_action)
 
     def test_update_else_actions(self):
@@ -206,7 +206,7 @@ class TestConditionalControls(unittest.TestCase):
         iterable_action = self.wntr.network.controls._ensure_iterable(new_action)
 
         self.assertNotEqual(wn.get_control(wn.control_name_list[0])._else_actions,iterable_action)
-        wn.get_control(wn.control_name_list[0]).update_else_actions(new_action, verbose=True)
+        wn.get_control(wn.control_name_list[0]).update_else_actions(new_action)
         self.assertEqual(wn.get_control(wn.control_name_list[0])._else_actions,iterable_action)
 
     def test_open_link_by_tank_level(self):

--- a/wntr/tests/test_network_controls.py
+++ b/wntr/tests/test_network_controls.py
@@ -159,6 +159,56 @@ class TestConditionalControls(unittest.TestCase):
         self.assertEqual(activated_flag, True)
         self.assertGreaterEqual(count, 2)
 
+    def test_update_priority(self):
+        inp_file = join(test_datadir, "conditional_controls_1.inp")
+        wn = self.wntr.network.WaterNetworkModel(inp_file)
+        new_priority =1 
+        idx = 0
+        # check current priority is different to the new one
+        self.assertNotEqual(wn.get_control(wn.control_name_list[idx]).priority, new_priority)
+        # Update priority and check it has worked
+        wn.get_control(wn.control_name_list[idx]).update_priority(new_priority)
+        self.assertEqual(wn.get_control(wn.control_name_list[idx]).priority, new_priority)
+
+    def test_update_conditions(self):
+        inp_file = join(test_datadir, "conditional_controls_1.inp")
+        wn = self.wntr.network.WaterNetworkModel(inp_file)
+        idx = 0
+        new_condition = self.wntr.network.controls.TimeOfDayCondition(wn, 'Is','01:00:00')
+
+        self.assertNotEqual(wn.get_control(wn.control_name_list[idx]).condition, new_condition)
+        wn.get_control(wn.control_name_list[idx]).update_condition(new_condition)
+        self.assertEqual(wn.get_control(wn.control_name_list[idx]).condition, new_condition)
+
+
+    def test_update_then_actions(self):
+        inp_file = join(test_datadir, "conditional_controls_1.inp")
+        wn = self.wntr.network.WaterNetworkModel(inp_file)
+        link_num=0
+        link = wn.get_link(wn.link_name_list[link_num])
+
+        new_action = self.wntr.network.controls.ControlAction(link, 'status', 0)
+        # When updating then_actions, the action will be made iterable, we need to make it iterable too.
+        iterable_action = self.wntr.network.controls._ensure_iterable(new_action)
+
+        self.assertNotEqual(wn.get_control(wn.control_name_list[0])._then_actions,iterable_action)
+        wn.get_control(wn.control_name_list[0]).update_then_actions(new_action)
+        self.assertEqual(wn.get_control(wn.control_name_list[0])._then_actions,iterable_action)
+
+    def test_update_else_actions(self):
+        inp_file = join(test_datadir, "conditional_controls_1.inp")
+        wn = self.wntr.network.WaterNetworkModel(inp_file)
+        link_num=0
+        link = wn.get_link(wn.link_name_list[link_num])
+
+        new_action = self.wntr.network.controls.ControlAction(link, 'status', 0)
+        # When updating then_actions, the action will be made iterable, we need to make it iterable too.
+        iterable_action = self.wntr.network.controls._ensure_iterable(new_action)
+
+        self.assertNotEqual(wn.get_control(wn.control_name_list[0])._else_actions,iterable_action)
+        wn.get_control(wn.control_name_list[0]).update_else_actions(new_action)
+        self.assertEqual(wn.get_control(wn.control_name_list[0])._else_actions,iterable_action)
+
     def test_open_link_by_tank_level(self):
         inp_file = join(test_datadir, "conditional_controls_2.inp")
         wn = self.wntr.network.WaterNetworkModel(inp_file)

--- a/wntr/tests/test_network_controls.py
+++ b/wntr/tests/test_network_controls.py
@@ -167,7 +167,7 @@ class TestConditionalControls(unittest.TestCase):
         # check current priority is different to the new one
         self.assertNotEqual(wn.get_control(wn.control_name_list[idx]).priority, new_priority)
         # Update priority and check it has worked
-        wn.get_control(wn.control_name_list[idx]).update_priority(new_priority)
+        wn.get_control(wn.control_name_list[idx]).update_priority(new_priority, verbose=True)
         self.assertEqual(wn.get_control(wn.control_name_list[idx]).priority, new_priority)
 
     def test_update_conditions(self):
@@ -177,7 +177,7 @@ class TestConditionalControls(unittest.TestCase):
         new_condition = self.wntr.network.controls.TimeOfDayCondition(wn, 'Is','01:00:00')
 
         self.assertNotEqual(wn.get_control(wn.control_name_list[idx]).condition, new_condition)
-        wn.get_control(wn.control_name_list[idx]).update_condition(new_condition)
+        wn.get_control(wn.control_name_list[idx]).update_condition(new_condition, verbose=True)
         self.assertEqual(wn.get_control(wn.control_name_list[idx]).condition, new_condition)
 
 
@@ -192,7 +192,7 @@ class TestConditionalControls(unittest.TestCase):
         iterable_action = self.wntr.network.controls._ensure_iterable(new_action)
 
         self.assertNotEqual(wn.get_control(wn.control_name_list[0])._then_actions,iterable_action)
-        wn.get_control(wn.control_name_list[0]).update_then_actions(new_action)
+        wn.get_control(wn.control_name_list[0]).update_then_actions(new_action, verbose=True)
         self.assertEqual(wn.get_control(wn.control_name_list[0])._then_actions,iterable_action)
 
     def test_update_else_actions(self):
@@ -206,7 +206,7 @@ class TestConditionalControls(unittest.TestCase):
         iterable_action = self.wntr.network.controls._ensure_iterable(new_action)
 
         self.assertNotEqual(wn.get_control(wn.control_name_list[0])._else_actions,iterable_action)
-        wn.get_control(wn.control_name_list[0]).update_else_actions(new_action)
+        wn.get_control(wn.control_name_list[0]).update_else_actions(new_action, verbose=True)
         self.assertEqual(wn.get_control(wn.control_name_list[0])._else_actions,iterable_action)
 
     def test_open_link_by_tank_level(self):


### PR DESCRIPTION
I wanted to experiment with changing Control/Rule parameters but found the current workflow more complex than it needed to be:
1. Find the rule you want to change
2. Extract the parameters you want to remain the same
3. Remove the rule
4. Create a new rule and add it to the network

So I decided to implement the following workflow:

1. Find the rule you want to change
2. Update the parameters you want to change

I have made the following changes to facilitate this:

1.  `wntr.network.controls.Control` inherited from `wntr.network.controls.Rule` and had very similar `__init__`, now `wntr.network.controls.Control` uses `super().__init__()` to simplify this and reduce code duplication
2. I added the following methods to `wntr.network.controls.Rule`: `update_condition`, `update_then_actions`, `update_else_actions`, and `update_priority`. I also added tests for all these methods
3. I noticed that code to ensure a value was iterable was duplicated a few times so I refactored it into the method `wntr.network.controls._ensure_iterable`
4. While running tests I noticed that `temp.json` was missing from the `.gitignore` so I added it.
