### PR TITLE
Distribute inp files used for testing

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,3 +7,4 @@ include wntr/sim/aml/*.pyd
 include wntr/sim/aml/*.so
 include wntr/sim/network_isolation/*.pyd
 include wntr/sim/network_isolation/*.so
+include wntr/tests/networks_for_testing/*.inp

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import os
 import re
 
 use_swig = False
-build = True
+build = False
 
 extension_modules = list()
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import os
 import re
 
 use_swig = False
-build = False
+build = True
 
 extension_modules = list()
 


### PR DESCRIPTION
This PR includes the inp files used for testing in `MANIFEST.in` so they get distributed with WNTR. This allows at least a subset of the tests to be run after installing WNTR.