### PR TITLE
Graphics update to include plt.show()

### DIFF
--- a/documentation/getting_started.rst
+++ b/documentation/getting_started.rst
@@ -7,7 +7,7 @@
 Getting started
 ======================================
 
-To start using WNTR, open a Python console and import the package::
+To start using WNTR, open a Python console or IDE like Spyder and import the package::
 
 	import wntr	
 
@@ -30,13 +30,26 @@ This example demonstrates how to:
 Additional examples are included throughout the WNTR documentation. The examples provided in the documentation assume
 that a user has experience using EPANET (https://www.epa.gov/water-research/epanet) and Python (https://www.python.org/), including the ability to install and use additional Python packages, such as those listed in :ref:`requirements` and :ref:`optional_dependencies`.
 
-
 Several EPANET INP files and example files are also included in the WNTR repository in the `examples folder <https://github.com/USEPA/WNTR/blob/main/examples>`_.
 Example networks range from a simple 9 node network to a 3,000 node network.
 Additional network models can be downloaded from the University of Kentucky 
 Water Distribution System Research Database at
 https://uknowledge.uky.edu/wdsrd.
 
+Example files can be run as follows:
+
+* Open a command line or PowerShell prompt and run the example file using Python in interactive mode.  
+  This will keep Python open so that graphics can be viewed.  Use ``exit()`` to close Python when done.  
+  For example, the getting started example can be run as follows::
+  
+      python -i getting_started.py
+      
+* Open a Python console in script mode (no -i) and copy/paste lines of code into the Python console. 
+  Use ``exit()`` to close Python when done.
+
+* Open the example file within an IDE like Spyder and run or step through the file. 
+
+    
 Additional examples
 -----------------------
 

--- a/wntr/graphics/curve.py
+++ b/wntr/graphics/curve.py
@@ -68,6 +68,8 @@ def plot_fragility_curve(FC, fill=True, key='Default',
     ax.set_ylabel(ylabel)
     ax.legend()
     
+    plt.show(block=False)
+    
     return ax
 
 def plot_pump_curve(pump, title='Pump curve', 
@@ -142,6 +144,8 @@ def plot_pump_curve(pump, title='Pump curve',
     ax.set_xlabel(xlabel)
     ax.set_ylabel(ylabel)
     ax.legend()
+    
+    plt.show(block=False)
     
     return ax
 
@@ -235,5 +239,7 @@ def plot_tank_volume_curve(tank, title='Tank volume curve',
     ax[1].set_xlim(xlim)
     ax[1].set_ylim(ylim)
     ax[1].legend()
+    
+    plt.show(block=False)
     
     return ax

--- a/wntr/graphics/network.py
+++ b/wntr/graphics/network.py
@@ -242,7 +242,9 @@ def plot_network(wn, node_attribute=None, link_attribute=None, title=None,
     
     if filename:
         plt.savefig(filename)
-        
+    
+    plt.show(block=False)
+    
     return ax
 
 def plot_interactive_network(wn, node_attribute=None, node_attribute_name = 'Value', title=None,


### PR DESCRIPTION
This PR adds plt.show(block=False) to matplotlib graphics within WNTR, including network plots and plots that show curves.    This ensures that graphics are shown when running WNTR outside Spyder.  If running examples directly from the command line, Python should be run in interactive mode (for example, python -i file.py).  Docs were updated to describe.  Using block=False ensures that the tests continue running after a graphic is created.