### PR TITLE
Emitter units

### DIFF
--- a/wntr/epanet/util.py
+++ b/wntr/epanet/util.py
@@ -638,8 +638,9 @@ class HydParam(enum.Enum):
             if self is HydParam.EmitterCoeff:
                 if flow_units.is_traditional:
                     # flowunit/sqrt(psi) from flowunit/sqrt(m), i.e.,
-                    # flowunit/sqrt(m) * sqrt( m/ft / psi/ft ) = flowunit/sqrt(psi)
-                    data = data * np.sqrt(0.3048 / 0.4333)
+                    # flowunit/sqrt(m) * sqrt( m/ft / psi/ft ) = flowunit/sqrt(psi), same as
+                    # flowunit/sqrt(m) / sqrt( psi/ft / m/ft ) = flowunit/sqrt(psi)
+                    data = data / np.sqrt( 0.4333 / 0.3048 )
         elif self in [HydParam.PipeDiameter]:
             if flow_units.is_traditional:
                 data = data / 0.0254  # in from m
@@ -678,8 +679,9 @@ class HydParam(enum.Enum):
 
         elif self in [HydParam.Pressure]:
             if flow_units.is_traditional:
-                # psi from m, i.e., m * (psi/ft / m/ft) = psi
-                data = data * (0.4333 / 0.3048 )  
+                # psi from m, i.e., m * (psi/ft / m/ft) = psi, same as
+                # m / ( m/ft / psi/m ) = psi
+                data = data / (0.3048 / 0.4333 )  
 
         elif self in [HydParam.Volume]:
             if flow_units.is_traditional:

--- a/wntr/epanet/util.py
+++ b/wntr/epanet/util.py
@@ -544,8 +544,9 @@ class HydParam(enum.Enum):
             data = data * flow_units.factor
             if self is HydParam.EmitterCoeff:
                 if flow_units.is_traditional:
-                    data = data * np.sqrt(0.7032)  # flowunit/psi0.5 to flowunit/m0.5
-
+                    # flowunit/sqrt(psi) to flowunit/sqrt(m), i.e.,
+                    # flowunit/sqrt(psi) * sqrt(psi/ft / m/ft ) = flowunit/sqrt(m)
+                    data = data * np.sqrt(0.4333 / 0.3048)   
         elif self in [HydParam.PipeDiameter]:
             if flow_units.is_traditional:
                 data = data * 0.0254  # in to m
@@ -584,8 +585,8 @@ class HydParam(enum.Enum):
 
         elif self in [HydParam.Pressure]:
             if flow_units.is_traditional:
-                #                data = data * 0.703249614902
-                data = data * (0.3048 / 0.4333)  # psi * (m/ft / psi/ft)
+                # psi to m, i.e., psi * (m/ft / psi/ft) = m
+                data = data * (0.3048 / 0.4333)  
 
         elif self in [HydParam.Volume]:
             if flow_units.is_traditional:
@@ -636,8 +637,9 @@ class HydParam(enum.Enum):
             data = data / flow_units.factor
             if self is HydParam.EmitterCoeff:
                 if flow_units.is_traditional:
-                    data = data / np.sqrt(0.7032)  # flowunit/psi0.5 from flowunit/m0.5
-
+                    # flowunit/sqrt(psi) from flowunit/sqrt(m), i.e.,
+                    # flowunit/sqrt(m) * sqrt( m/ft / psi/ft ) = flowunit/sqrt(psi)
+                    data = data * np.sqrt(0.3048 / 0.4333)
         elif self in [HydParam.PipeDiameter]:
             if flow_units.is_traditional:
                 data = data / 0.0254  # in from m
@@ -676,10 +678,8 @@ class HydParam(enum.Enum):
 
         elif self in [HydParam.Pressure]:
             if flow_units.is_traditional:
-                #                data = data / 0.703249614902
-                data = data / (
-                    0.3048 / 0.4333
-                )  # psi from mH2O, i.e. psi / (m/ft / psi/ft) )
+                # psi from m, i.e., m * (psi/ft / m/ft) = psi
+                data = data * (0.4333 / 0.3048 )  
 
         elif self in [HydParam.Volume]:
             if flow_units.is_traditional:

--- a/wntr/tests/test_epanet_units.py
+++ b/wntr/tests/test_epanet_units.py
@@ -41,8 +41,38 @@ class TestEpanetUnits(unittest.TestCase):
                     data = 86400.0  # m3/d
                 self.execute_check(typestring, flowunit, data, data_expected)
 
-    def test_emitter_coefficient(self):
-        pass
+    def test_Emitter_Coeff(self):
+        data_expected = 1.0  # (m3/s)/sqrt(m)
+        typestring = "EmitterCoeff"
+        data_expected = 1  # m
+        for flowunit in range(10):
+            if flowunit == 0:
+                data = 35.3146667  # ft3/s
+            elif flowunit == 1:
+                data = 15850.3231  # gall/min
+            elif flowunit == 2:
+                data = 22.8244653  # million gall/d
+            elif flowunit == 3:
+                data = 19.0  # million imperial gall/d
+            elif flowunit == 4:
+                data = 70.0456199  # acre-feet/day
+            elif flowunit == 5:
+                data = 1000.0  # L/s
+            elif flowunit == 6:
+                data = 60000.0  # L/min
+            elif flowunit == 7:
+                data = 86.4  # million L/d
+            elif flowunit == 8:
+                data = 3600.0  # m3/h
+            elif flowunit == 9:
+                data = 86400.0  # m3/d
+
+            if flowunit in [0, 1, 2, 3, 4]:
+                data = data/np.sqrt(1.421970206324753)  # flowrate/sqrt(psi)
+            else:
+                data = data # flowrate/sqrt(m)
+                
+            self.execute_check(typestring, flowunit, data, data_expected)
 
     def test_Pipe_Diameter(self):
         typestring = "PipeDiameter"


### PR DESCRIPTION
This PR includes a bug fix for emitter coefficient unit conversion between flowunit/sqrt(psi) and flowunit/sqrt(m).  The conversion now uses 0.4333 psi/ft and 0.3048 m/ft to match the way pressure is converted in WNTR.  The corrected conversion is flowunit/sqrt(psi) * sqrt( 0.4333 psi/ft / 0.3048 m/ft ) = flowunit/sqrt(m).  A test was added that includes all 10 EPANET flowunits.
