### PR TITLE
doc: Corrected typo

### DIFF
--- a/documentation/waternetworkmodel.rst
+++ b/documentation/waternetworkmodel.rst
@@ -252,7 +252,7 @@ Reset initial conditions
 
 When using the same water network model to run multiple simulations using the WNTRSimulator, initial conditions need to be reset between simulations.  
 Initial conditions include simulation time, tank head, reservoir head, pipe status, pump status, and valve status.
-When using the EpanetSimualtor, this step is not needed since EPANET starts at the initial conditions each time it is run.
+When using the EpanetSimulator, this step is not needed since EPANET starts at the initial conditions each time it is run.
 
 .. doctest::
 


### PR DESCRIPTION
EpanetSimulator was wrongly spelt as EpanetSimualtor in the "Reset initial conditions" section.