### PR TITLE
Added a build input argument to setup.py

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -31,7 +31,7 @@ jobs:
         pip install -r requirements.txt
     - name: Build wheel
       run: |
-        python setup.py bdist_wheel
+        python setup.py bdist_wheel --build
         ls dist/*
     - name: Save wheel
       uses: actions/upload-artifact@v3

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -5,7 +5,7 @@ name: build
 
 on:
   push:
-    branches: [ main, dev, setup ]
+    branches: [ main, dev ]
   pull_request:
     branches: [ main, dev ]
 

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -5,7 +5,7 @@ name: build
 
 on:
   push:
-    branches: [ main, dev ]
+    branches: [ main, dev, setup ]
   pull_request:
     branches: [ main, dev ]
 
@@ -85,7 +85,7 @@ jobs:
         python --version
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        python setup.py develop
+        python setup.py develop --build
     - name: Run Tests on Windows
       if: matrix.os == 'windows-latest'
       run: | # the following skips windows rst doctests that rely on geopandas (gis.rst) because skipif is not working properly
@@ -122,7 +122,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        python setup.py develop
+        python setup.py develop --build
     # pip install coveralls
     - name: Download coverage artifacts from test matrix
       uses: actions/download-artifact@v2
@@ -169,7 +169,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install coveralls
         pip install -r requirements.txt
-        python setup.py develop
+        python setup.py develop --build
     - name: Download coverage artifacts from test matrix
       uses: actions/download-artifact@v2
       with:

--- a/.github/workflows/quick_check.yml
+++ b/.github/workflows/quick_check.yml
@@ -31,7 +31,7 @@ jobs:
     # Build extensions are accessible from package level, similar to python setup.py build_ext --inplace
     - name: Install package for development
       run: |
-        python setup.py develop
+        python setup.py develop --build
     - name: Run tests and coverage (unittests plus doctests)
       run: |
         coverage run --source=wntr --omit="*/tests/*" -m pytest -m "not time_consuming" --doctest-modules --doctest-glob="*.rst" wntr        

--- a/.github/workflows/quick_check.yml
+++ b/.github/workflows/quick_check.yml
@@ -28,7 +28,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install --upgrade coverage pytest
-    # Build extensions are accessible from package level, similar to python setup.py build_ext --inplace
     - name: Install package for development
       run: |
         python setup.py develop --build

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ wntr.egg-info/
 dist/
 docker/
 
+*.pyd
 *.pyc
 *.egg
 *.coverage

--- a/documentation/installation.rst
+++ b/documentation/installation.rst
@@ -12,7 +12,8 @@ See :ref:`requirements` and :ref:`optional_dependencies` for more information.
 WNTR can be installed as a Python package as briefly described below. 
 :ref:`detailed_instructions` are included in the following section.
 
-Users can install the latest release of WNTR from PyPI or Anaconda using one of the following commands in a command line or PowerShell prompt.
+Users can install the latest release of WNTR from PyPI or Anaconda using one of the 
+following commands in a terminal, command line, or PowerShell prompt. 
 
 .. only:: html
 
@@ -250,8 +251,8 @@ Developer instructions
 -------------------------
 
 Developers can clone and setup the main branch of WNTR from the GitHub 
-repository using the following commands in a command line or PowerShell prompt. 
-WNTR includes C++ code that can be built into pyd files using the optional ``--build`` command line argument.
+repository using the following commands in a terminal, command line, or PowerShell prompt. 
+WNTR includes C++ code that can be built into shared object files (e.g., pyd for Windows) using the optional ``--build`` command line argument.
 This requires that the developer has a C++ compiler on their path::
 
     git clone https://github.com/USEPA/WNTR
@@ -259,14 +260,16 @@ This requires that the developer has a C++ compiler on their path::
     python setup.py develop --build
 
 If the developer does NOT have a C++ compiler, or would rather use prebuilt wheels,
-the pyd files can be downloaded from WNTR GitHub Actions using the following steps:
+the shared object files can be downloaded from WNTR GitHub Actions using the following steps:
 
 * Clone and setup the main branch of WNTR from the GitHub repository as shown above, but omit the ``--build`` command line argument
 * Select the latest GitHub Actions build_tests that uses the main branch from https://github.com/USEPA/WNTR/actions/workflows/build_tests.yml
 * Scroll down to "Artifacts"
 * Download the wheel that matches the desired operating system and Python version (for example, wntr_3.9_windows-latest.whl)
-* Unzip the wheel and locate the following files (which are named according to the operating system and Python version): wntr\sim\aml\_evaluator.cp39-win_amd64.pyd, wntr\sim\network_isolation\_network_isolation.cp39-win_amd64.pyd
-* Copy these files into the matching directly in the cloned version of WNTR
+* Unzip the wheel and locate the following files (which are named according to the operating system and Python version)
+   * wntr\sim\aml\_evaluator.cp39-win_amd64.pyd
+   * wntr\sim\network_isolation\_network_isolation.cp39-win_amd64.pyd
+* Copy these files into the matching directory in the cloned version of WNTR
 
 Note that users installing WNTR through PyPI or conda do not need to compile code.
 

--- a/documentation/installation.rst
+++ b/documentation/installation.rst
@@ -44,15 +44,6 @@ Users can install the latest release of WNTR from PyPI or Anaconda using one of 
 .. |anaconda downloads| image:: https://anaconda.org/conda-forge/wntr/badges/downloads.svg
 .. _anaconda downloads: https://anaconda.org/conda-forge/wntr
 
-Developers can install the main branch of WNTR from the GitHub 
-repository using the following commands in a command line or PowerShell prompt::
-
-    git clone https://github.com/USEPA/WNTR
-    cd WNTR
-    python setup.py develop
-
-More information for developers can be found in the :ref:`developers` section.
-
 .. _detailed_instructions:
 
 Detailed instructions
@@ -254,3 +245,29 @@ All of these packages **except geopandas** are included in the Anaconda Python d
 	* Extract the zip file and save the files to the bin folder for Ipopt.  For example, if Ipopt was saved 
 	  in C:/Program Files/COIN-OR/1.7.4/win32-msvc11, extract the HSL zip file, copy the files from the extracted folder, and paste them in 
 	  C:/Program Files/COIN-OR/1.7.4/win32-msvc11/bin.
+
+Developer instructions
+-------------------------
+
+Developers can clone and setup the main branch of WNTR from the GitHub 
+repository using the following commands in a command line or PowerShell prompt. 
+WNTR includes C++ code that can be built into pyd files using the optional ``--build`` command line argument.
+This requires that the developer has a C++ compiler on their path::
+
+    git clone https://github.com/USEPA/WNTR
+    cd WNTR
+    python setup.py develop --build
+
+If the developer does NOT have a C++ compiler, or would rather use prebuilt wheels,
+the pyd files can be downloaded from WNTR GitHub Actions using the following steps:
+
+* Clone and setup the main branch of WNTR from the GitHub repository as shown above, but omit the ``--build`` command line argument
+* Select the latest GitHub Actions build_tests that uses the main branch from https://github.com/USEPA/WNTR/actions/workflows/build_tests.yml
+* Scroll down to "Artifacts"
+* Download the wheel that matches the desired operating system and Python version (for example, wntr_3.9_windows-latest.whl)
+* Unzip the wheel and locate the following files (which are named according to the operating system and Python version): wntr\sim\aml\_evaluator.cp39-win_amd64.pyd, wntr\sim\network_isolation\_network_isolation.cp39-win_amd64.pyd
+* Copy these files into the matching directly in the cloned version of WNTR
+
+Note that users installing WNTR through PyPI or conda do not need to compile code.
+
+More information for developers can be found in the :ref:`developers` section.

--- a/documentation/whatsnew/v0.5.0.rst
+++ b/documentation/whatsnew/v0.5.0.rst
@@ -21,10 +21,13 @@ v0.5.0 (main)
 
 * Added support for Python 3.10, dropped support for Python 3.6.
   The build workflow now creates wheel artifacts.  
-  The `_evaluator` and `_network_isolation` binaries are also 
-  distributed with the code. `#287 <https://github.com/USEPA/WNTR/pull/287>`_, 
+  `#287 <https://github.com/USEPA/WNTR/pull/287>`_, 
   `#294 <https://github.com/USEPA/WNTR/pull/294>`_
 
+* The `_evaluator` and `_network_isolation` binaries are no longer 
+  distributed with the code.  The setup.py file now includes an optional argument to build the binaries.
+  Developer installation instructions have been updated.
+  
 * Updated documentation `#291 <https://github.com/USEPA/WNTR/pull/291>`_, 
   `#292 <https://github.com/USEPA/WNTR/pull/292>`_
  

--- a/setup.py
+++ b/setup.py
@@ -6,14 +6,14 @@ import sys
 
 use_swig = False
 
-extension_modules = list()
-
 if '--build' in sys.argv:
     build = True
     sys.argv.remove('--build')
 else:
     build = False
     
+
+extension_modules = list()
 if build:
     import numpy
 

--- a/setup.py
+++ b/setup.py
@@ -5,14 +5,15 @@ import re
 import sys
 
 use_swig = False
-build = True
 
 extension_modules = list()
 
-# if sys.version_info.major >= 3 and sys.version_info.minor >= 10:
-#     print("Python version >= 3.10.x")
-#     build = True
-
+if '--build' in sys.argv:
+    build = True
+    sys.argv.remove('--build')
+else:
+    build = False
+    
 if build:
     import numpy
 

--- a/wntr/tests/test_sim_performance.py
+++ b/wntr/tests/test_sim_performance.py
@@ -267,7 +267,7 @@ class TestPerformance(unittest.TestCase):
         t1.join()
         t2.join()
         thr_time = time.time()-start_time
-        self.assertGreaterEqual(seq_time, thr_time, 'EPANET threading took longer than sequential')
+        self.assertGreaterEqual(seq_time - thr_time, -0.1, 'EPANET threading took longer than sequential')
 
         start_time = time.time()
         run_wntr(wn1, 'temp1')
@@ -282,7 +282,7 @@ class TestPerformance(unittest.TestCase):
         t1.join()
         t2.join()
         thr_time = time.time()-start_time
-        self.assertGreaterEqual(seq_time, thr_time, 'WNTR threading took longer than sequential')
+        self.assertGreaterEqual(seq_time - thr_time, -0.1, 'WNTR threading took longer than sequential')
 
     def test_Net6_mod_performance(self):
         head_diff_abs_threshold = 1e-3


### PR DESCRIPTION
* Added a `--build` input argument to setup.py to build the shared object files 
* Updated developer installation instructions.  Now that the shared object files are not distributed with the code, developers should run `python setup.py develop --build` or download the files from GitHub Actions.
* Updated workflow yml files
* Updated release notes
* Added a buffer to the sequential vs. threading timing test