### PR TITLE
Type checking for time options

### DIFF
--- a/wntr/epanet/io.py
+++ b/wntr/epanet/io.py
@@ -1126,7 +1126,7 @@ class InpFile(object):
                 f.write('{:10s} {:10s}\n'.format(pump_name, LinkStatus(pump.initial_status).name).encode('latin-1'))
             else:
                 setting = pump.initial_setting
-                if type(setting) is float and setting != 1.0:
+                if isinstance(setting, float) and setting != 1.0:
                     f.write('{:10s} {:10.7g}\n'.format(pump_name, setting).encode('latin-1'))
         
         vnames = list(wn.valve_name_list)
@@ -1662,8 +1662,7 @@ class InpFile(object):
                         edata['key'] = words[0] + ' ' + words[1]
                         setattr(opts, words[0].lower() + '_' + words[1].lower(), float(words[2]))
                         logger.warn('%(lnum)-6d %(sec)13s option "%(key)s" is undocumented; adding, but please verify syntax', edata)
-        if (type(opts.time.report_timestep) == float or
-                type(opts.time.report_timestep) == int):
+        if isinstance(opts.time.report_timestep, (float, int)):
             if opts.time.report_timestep < opts.time.hydraulic_timestep:
                 raise RuntimeError('opts.report_timestep must be greater than or equal to opts.hydraulic_timestep.')
             if opts.time.report_timestep % opts.time.hydraulic_timestep != 0:
@@ -2994,13 +2993,13 @@ def _compare_lines(line1, line2, tol=1e-14):  # pragma: no cover
 
     for i, a in enumerate(line1):
         b = line2[i]
-        if type(a) not in {int, float}:
+        if isinstance(a, (int, float)):
             if a != b:
                 return False
-        elif type(a) is int and type(b) is int:
+        elif isinstance(a, int) and isinstance(b, int):
             if a != b:
                 return False
-        elif type(a) in {int, float} and type(b) in {int, float}:
+        elif isinstance(a, (int, float)) and isinstance(b, (int, float)):
             if abs(a - b) > tol:
                 return False
         else:
@@ -3028,7 +3027,7 @@ def _clean_line(wn, sec, line):  # pragma: no cover
             other = wn.options.hydraulic.pattern
             if other is None:
                 other = 1
-            if (type(line[3]) is int) and (other is int):
+            if isinstance(line[3], int) and isinstance(other, int):
                 other = int(other)
             if line[3] == other:
                 return line[:3]

--- a/wntr/epanet/util.py
+++ b/wntr/epanet/util.py
@@ -346,11 +346,13 @@ class QualParam(enum.Enum):
             The data values converted to SI standard units
 
         """
-        data_type = type(data)
-        if data_type is dict:
+        original_data_type = None
+        if isinstance(data, dict):
+            original_data_type = 'dict'
             data_keys = data.keys()
             data = np.array(data.values())
-        elif data_type is list:
+        elif isinstance(data, list):
+            original_data_type = 'list'
             data = np.array(data)
 
         if mass_units is None:
@@ -388,10 +390,11 @@ class QualParam(enum.Enum):
             data = data * 3600.0  # hr to s
 
         # Convert back to input data type
-        if data_type is dict:
+        if original_data_type == 'dict':
             data = dict(zip(data_keys, data))
-        elif data_type is list:
+        elif original_data_type == 'list': 
             data = list(data)
+            
         return data
 
     def _from_si(self, flow_units, data, mass_units=MassUnits.mg, reaction_order=0):
@@ -416,11 +419,13 @@ class QualParam(enum.Enum):
             The data values converted to EPANET appropriate units, based on the flow units.
 
         """
-        data_type = type(data)
-        if data_type is dict:
+        original_data_type = None
+        if isinstance(data, dict):
+            original_data_type = 'dict'
             data_keys = data.keys()
             data = np.array(data.values())
-        elif data_type is list:
+        elif isinstance(data, list):
+            original_data_type = 'list'
             data = np.array(data)
 
         # Do conversions
@@ -455,10 +460,11 @@ class QualParam(enum.Enum):
             data = data / 3600.0  # hr fr s
 
         # Convert back to input data type
-        if data_type is dict:
+        if original_data_type == 'dict':
             data = dict(zip(data_keys, data))
-        elif data_type is list:
+        elif original_data_type == 'list':
             data = list(data)
+            
         return data
 
 
@@ -557,15 +563,18 @@ class HydParam(enum.Enum):
 
         """
         # Convert to array for unit conversion
-        data_type = type(data)
-        if data_type is pd.core.frame.DataFrame:
+        original_data_type = None
+        if isinstance(data, pd.core.frame.DataFrame):
+            original_data_type = 'dataframe'
             data_index = data.index
             data_columns = data.columns
             data = data.values
-        elif data_type is dict:
+        elif isinstance(data, dict):
+            original_data_type = 'dict'
             data_keys = data.keys()
             data = np.array(list(data.values()))
-        elif data_type is list:
+        elif isinstance(data, list):
+            original_data_type = 'list'
             data = np.array(data)
 
         # Do conversions
@@ -622,12 +631,13 @@ class HydParam(enum.Enum):
                 data = data * np.power(0.3048, 3)  # ft3 to m3
 
         # Convert back to input data type
-        if data_type is pd.core.frame.DataFrame:
+        if original_data_type == 'dataframe':
             data = pd.DataFrame(data, columns=data_columns, index=data_index)
-        elif data_type is dict:
+        elif original_data_type == 'dict':
             data = dict(zip(data_keys, data))
-        elif data_type is list:
+        elif original_data_type == 'list':
             data = list(data)
+        
         return data
 
     def _from_si(self, flow_units, data, darcy_weisbach=False):
@@ -654,11 +664,13 @@ class HydParam(enum.Enum):
 
         """
         # Convert to array for conversion
-        data_type = type(data)
-        if data_type is dict:
+        original_data_type = None
+        if isinstance(data, dict):
+            original_data_type = 'dict'
             data_keys = data.keys()
             data = np.array(list(data.values()))
-        elif data_type is list:
+        elif isinstance(data, list):
+            original_data_type = 'list'
             data = np.array(data)
 
         # Do onversions
@@ -717,10 +729,11 @@ class HydParam(enum.Enum):
                 data = data / np.power(0.3048, 3)  # ft3 from m3
 
         # Put back into data format passed in
-        if data_type is dict:
+        if original_data_type  == 'dict':
             data = dict(zip(data_keys, data))
-        elif data_type is list:
+        elif original_data_type == 'list':
             data = list(data)
+            
         return data
 
 

--- a/wntr/network/controls.py
+++ b/wntr/network/controls.py
@@ -1728,7 +1728,7 @@ class BaseControlAction(six.with_metaclass(abc.ABCMeta, Subject)):
             return False
         if attr1 != attr2:
             return False
-        if type(val1) == float:
+        if isinstance(val1, float):
             if abs(val1 - val2) > 1e-10:
                 return False
         else:

--- a/wntr/sim/core.py
+++ b/wntr/sim/core.py
@@ -198,13 +198,13 @@ class _Diagnostics(object): # pragma: no cover
                 print('could not load {0} into the model because {0} is not an attribute of the model'.format(v_name))
                 continue
             v = getattr(self.model, v_name)
-            if type(val) == dict:
+            if isinstance(val, dict):
                 for key, _val in val.items():
                     if key not in v:
                         print('could not load {0}[{1}] into the model because {1} is not an element in model.{0}'.format(v_name, key))
                         continue
                     _v = v[key]
-                    if type(_v) == Var:
+                    if isinstance(_v, Var):
                         _v.value = _val
                     else:
                         if abs(_v.value - _val) > 1e-6:
@@ -213,7 +213,7 @@ class _Diagnostics(object): # pragma: no cover
                                 print('  from solution file: {0}'.format(_val))
                                 print('  from model: {0}'.format(_v.value))
             else:
-                if type(v) == Var:
+                if isinstance(v, Var):
                     v.value = val
                 else:
                     if abs(v.value - val) > 1e-6:
@@ -666,7 +666,7 @@ class WNTRSimulator(WaterNetworkSimulator):
     def _setup_sim_options(self, solver, backup_solver, solver_options, backup_solver_options, convergence_error):
         self._report_timestep = self._wn.options.time.report_timestep
         self._hydraulic_timestep = self._wn.options.time.hydraulic_timestep
-        if type(self._report_timestep) is str:
+        if isinstance(self._report_timestep, str):
             if self._report_timestep.upper() != 'ALL':
                 raise ValueError('report timestep must be either an integer number of seconds or "ALL".')
         else:

--- a/wntr/sim/core.py
+++ b/wntr/sim/core.py
@@ -373,7 +373,7 @@ class _Diagnostics(object): # pragma: no cover
             link_text = str(link.link_type) + ' ' + str(link)
             for _attr in link_attributes:
                 val = getattr(link, _attr)
-                if type(val) == float:
+                if isinstance(val, float):
                     val = round(val, round_ndigits)
                 link_text += '<br />{0}: {1}'.format(_attr, str(val))
             link_text += '<br />{0}: {1}'.format('x_coord', 0.5 * (x0 + x1))
@@ -391,7 +391,7 @@ class _Diagnostics(object): # pragma: no cover
             node_text = str(_node.node_type) + ' ' + str(_node)
             for _attr in node_attributes:
                 val = getattr(_node, _attr)
-                if type(val) == float:
+                if isinstance(val, float):
                     val = round(val, round_ndigits)
                 node_text += '<br />{0}: {1}'.format(_attr, str(val))
             try:
@@ -1333,7 +1333,7 @@ class WNTRSimulator(WaterNetworkSimulator):
             logger.debug('no changes made by postsolve controls; moving to next timestep')
 
             resolve = False
-            if type(self._report_timestep) == float or type(self._report_timestep) == int:
+            if isinstance(self._report_timestep, (float, int)):
                 if self._wn.sim_time % self._report_timestep == 0:
                     wntr.sim.hydraulics.save_results(self._wn, node_res, link_res)
                     if len(results.time) > 0 and int(self._wn.sim_time) == results.time[-1]:

--- a/wntr/tests/test_sim_performance.py
+++ b/wntr/tests/test_sim_performance.py
@@ -3,6 +3,7 @@ import unittest
 from os.path import abspath, dirname, join
 import threading
 import time
+import numpy as np
 
 import pandas
 
@@ -61,7 +62,7 @@ class TestPerformance(unittest.TestCase):
             pump.pump_curve_name = new_curve_name
         for pump_name, pump in wn2.pumps():
             pump.pump_curve_name = new_curve_name
-
+        
         epa_sim = self.wntr.sim.EpanetSimulator(wn)
         epa_res = epa_sim.run_sim()
 
@@ -93,6 +94,27 @@ class TestPerformance(unittest.TestCase):
             )
         )
 
+    def test_Net1_float64(self):
+        """Only needs to test that runs successfully with float64 time options"""
+        inp_file = join(ex_datadir, "Net1.inp")
+        wn = self.wntr.network.WaterNetworkModel(inp_file)
+        
+        wn.options.time.duration = np.float64(wn.options.time.duration)
+        wn.options.time.hydraulic_timestep = np.float64(wn.options.time.hydraulic_timestep)
+        wn.options.time.quality_timestep = np.float64(wn.options.time.quality_timestep)
+        wn.options.time.rule_timestep = np.float64(wn.options.time.rule_timestep)
+        wn.options.time.pattern_timestep = np.float64(wn.options.time.pattern_timestep)
+        wn.options.time.pattern_start = np.float64(wn.options.time.pattern_start)
+        wn.options.time.report_timestep = np.float64(wn.options.time.report_timestep)
+        wn.options.time.report_start = np.float64(wn.options.time.report_start)
+        wn.options.time.start_clocktime = np.float64(wn.options.time.start_clocktime)
+        
+        epa_sim = self.wntr.sim.EpanetSimulator(wn)
+        epa_res = epa_sim.run_sim()
+
+        sim = self.wntr.sim.WNTRSimulator(wn)
+        results = sim.run_sim()
+    
     def test_Net1_charset(self):
         """Only needs to test that runs successfully with latin-1 character set."""
         inp_file = join(test_datadir, "latin1.inp")


### PR DESCRIPTION
## Summary
This PR resolves #329.  Several cases of `type(x) is int` and `type(x) is float` have been updated to use `isinstance(x, (int, float))`

## Tests and documentation
Test added in test_sim_performance.py, this specifically tests the use `np.float64` in `wn.options.time`
 
## Acknowledgement
By contributing to this software project, I acknowledge that I have reviewed the [software quality assurance guidelines](https://wntr.readthedocs.io/en/stable/developers.html) and that my contributions are submitted under the [Revised BSD License](https://wntr.readthedocs.io/en/stable/license.html). 
