### PR TITLE
Minor update to the snap function and cleanup

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -90,16 +90,16 @@ jobs:
       if: matrix.os == 'windows-latest'
       run: | # the following skips windows rst doctests that rely on geopandas (gis.rst and model_io.rst) because skipif is not working properly
         coverage erase
-        coverage run --context=${{ matrix.os }}.py${{ matrix.python-version }} --source=wntr --omit="*/tests/*" -m pytest  --doctest-modules --doctest-glob="*.rst" wntr
-        coverage run --context=${{ matrix.os }}.py${{ matrix.python-version }} --source=wntr --omit="*/tests/*" --append -m pytest --doctest-glob="*.rst" --ignore-glob="*model_io.rst" --ignore-glob="*gis.rst" documentation
+        coverage run --context=${{ matrix.os }}.py${{ matrix.python-version }} --source=wntr --omit="*/tests/*","*/sim/network_isolation/network_isolation.py","*/sim/aml/evaluator.py" -m pytest  --doctest-modules --doctest-glob="*.rst" wntr
+        coverage run --context=${{ matrix.os }}.py${{ matrix.python-version }} --source=wntr --omit="*/tests/*","*/sim/network_isolation/network_isolation.py","*/sim/aml/evaluator.py" --append -m pytest --doctest-glob="*.rst" --ignore-glob="*model_io.rst" --ignore-glob="*gis.rst" documentation
       env:
         COVERAGE_FILE: .coverage.${{ matrix.python-version }}.${{ matrix.os }}
     - name: Run Tests
       if: matrix.os != 'windows-latest'
       run: | 
         coverage erase
-        coverage run --context=${{ matrix.os }}.py${{ matrix.python-version }} --source=wntr --omit="*/tests/*" -m pytest  --doctest-modules --doctest-glob="*.rst" wntr
-        coverage run --context=${{ matrix.os }}.py${{ matrix.python-version }} --source=wntr --omit="*/tests/*" --append -m pytest --doctest-glob="*.rst" documentation
+        coverage run --context=${{ matrix.os }}.py${{ matrix.python-version }} --source=wntr --omit="*/tests/*","*/sim/network_isolation/network_isolation.py","*/sim/aml/evaluator.py" -m pytest  --doctest-modules --doctest-glob="*.rst" wntr
+        coverage run --context=${{ matrix.os }}.py${{ matrix.python-version }} --source=wntr --omit="*/tests/*","*/sim/network_isolation/network_isolation.py","*/sim/aml/evaluator.py" --append -m pytest --doctest-glob="*.rst" documentation
       env:
         COVERAGE_FILE: .coverage.${{ matrix.python-version }}.${{ matrix.os }}
         

--- a/.github/workflows/quick_check.yml
+++ b/.github/workflows/quick_check.yml
@@ -33,7 +33,7 @@ jobs:
         python -m pip install -e .
     - name: Run tests and coverage (unittests plus doctests)
       run: |
-        coverage run --source=wntr --omit="*/tests/*" -m pytest -m "not time_consuming" --doctest-modules --doctest-glob="*.rst" wntr        
+        coverage run --source=wntr --omit="*/tests/*, */network_isolation.py, */evaluator.py" -m pytest -m "not time_consuming" --doctest-modules --doctest-glob="*.rst" wntr        
         coverage report --fail-under=70        
     # coverage run --source=wntr --omit="*/tests/*" --append -m pytest --doctest-glob="*.rst" documentation 
 

--- a/.github/workflows/quick_check.yml
+++ b/.github/workflows/quick_check.yml
@@ -33,7 +33,7 @@ jobs:
         python -m pip install -e .
     - name: Run tests and coverage (unittests plus doctests)
       run: |
-        coverage run --source=wntr --omit="*/tests/*, */sim/network_isolation/network_isolation.py, */sim/aml/evaluator.py" -m pytest -m "not time_consuming" --doctest-modules --doctest-glob="*.rst" wntr        
+        coverage run --source=wntr --omit="*/tests/*","*/sim/network_isolation/network_isolation.py","*/sim/aml/evaluator.py" -m pytest -m "not time_consuming" --doctest-modules --doctest-glob="*.rst" wntr        
         coverage report --fail-under=70        
     # coverage run --source=wntr --omit="*/tests/*" --append -m pytest --doctest-glob="*.rst" documentation 
 

--- a/.github/workflows/quick_check.yml
+++ b/.github/workflows/quick_check.yml
@@ -33,7 +33,7 @@ jobs:
         python -m pip install -e .
     - name: Run tests and coverage (unittests plus doctests)
       run: |
-        coverage run --source=wntr --omit="*/tests/*, */network_isolation.py, */evaluator.py" -m pytest -m "not time_consuming" --doctest-modules --doctest-glob="*.rst" wntr        
+        coverage run --source=wntr --omit="*/tests/*, */sim/network_isolation/network_isolation.py, */sim/aml/evaluator.py" -m pytest -m "not time_consuming" --doctest-modules --doctest-glob="*.rst" wntr        
         coverage report --fail-under=70        
     # coverage run --source=wntr --omit="*/tests/*" --append -m pytest --doctest-glob="*.rst" documentation 
 

--- a/documentation/whatsnew.rst
+++ b/documentation/whatsnew.rst
@@ -1,9 +1,9 @@
 Release notes
 ================
 
-.. _whatsnew_060:
+.. _whatsnew_100:
 
-.. include:: whatsnew/v0.6.0.rst
+.. include:: whatsnew/v1.0.0.rst
 
 .. _whatsnew_050:
 

--- a/documentation/whatsnew/v1.0.0.rst
+++ b/documentation/whatsnew/v1.0.0.rst
@@ -1,14 +1,12 @@
-v1.0.0 (main)
+v1.0.0 (March 30, 2023)
 ---------------------------------------------------
 WNTR version 1.0.0 has undergone extensive testing 
-with a wide range of water distribution systems model
+with a wide range of water distribution system models
 and analysis options. The software has also successfully been
 used by external research groups and in analysis that uses large-scale 
-water distribution systems models, see 
+water distribution system models. See 
 `User community <https://wntr.readthedocs.io/en/latest/users.html>`_ 
-for a list of publications and software that use WNTR.
-WNTR will continue to be developed to support water distribution 
-system resilience analysis. 
+for a list of publications and software that uses WNTR.
 
 * Updated copyright and added EPANET license
   `#336 <https://github.com/USEPA/WNTR/pull/336>`_.

--- a/documentation/whatsnew/v1.0.0.rst
+++ b/documentation/whatsnew/v1.0.0.rst
@@ -1,5 +1,21 @@
-v0.6.0 (main)
+v1.0.0 (main)
 ---------------------------------------------------
+WNTR version 1.0.0 has undergone extensive testing 
+with a wide range of water distribution systems model
+and analysis options. The software has also successfully been
+used by external research groups and in analysis that uses large-scale 
+water distribution systems models, see 
+`User community <https://wntr.readthedocs.io/en/latest/users.html>`_ 
+for a list of publications and software that use WNTR.
+WNTR will continue to be developed to support water distribution 
+system resilience analysis. 
+
+* Updated copyright and added EPANET license
+  `#336 <https://github.com/USEPA/WNTR/pull/336>`_.
+  
+* Updated the setup process and documentation
+  `#335 <https://github.com/USEPA/WNTR/pull/335>`_.
+	
 * Bug fix to allow for np.float and np.int in type checking 
   `#334 <https://github.com/USEPA/WNTR/pull/334>`_.
   

--- a/wntr/__init__.py
+++ b/wntr/__init__.py
@@ -1,15 +1,3 @@
-# shapely and geopandas are optional dependencies of WNTR. If shapely 
-# version is >= 2.0, the environment variable USE_PYGEOS is set to '0' to 
-# ensure geopandas uses shapely over pygeos. Future versions of 
-# geopandas will use shapely by default.
-try:
-    import shapely
-    if int(shapely.__version__.split('.')[0]) >= 2:
-        import os
-        os.environ['USE_PYGEOS'] = '0'
-except ModuleNotFoundError:
-    pass
-
 from wntr import epanet
 from wntr import network
 from wntr import morph

--- a/wntr/__init__.py
+++ b/wntr/__init__.py
@@ -8,7 +8,7 @@ from wntr import graphics
 from wntr import gis
 from wntr import utils
 
-__version__ = '0.6.0dev'
+__version__ = '1.0.0'
 
 __copyright__ = """Copyright 2023 National Technology & Engineering 
 Solutions of Sandia, LLC (NTESS). Under the terms of Contract DE-NA0003525 

--- a/wntr/gis/geospatial.py
+++ b/wntr/gis/geospatial.py
@@ -49,7 +49,7 @@ def snap(A, B, tolerance):
         
         If B contains Lines or MultiLineString, columns include:
             - link: closest Line in B to Point in A
-            - node: start or end node of Line in B that is closest to the snapped point
+            - node: start or end node of Line in B that is closest to the snapped point (if B contains columns "start_node_name" and "end_node_name")
             - snap_distance: distance between Point A and snapped point
             - line_position: normalized distance of snapped point along Line in B from the start node (0.0) and end node (1.0)
             - geometry: GeoPandas Point object of the snapped point
@@ -126,9 +126,12 @@ def snap(A, B, tolerance):
         snapped_points = gpd.GeoDataFrame(data=closest ,geometry=snapped_points, crs=crs)
         # determine whether the snapped point is closer to the start or end node
         snapped_points["line_position"] = closest.geometry.project(snapped_points, normalized=True)
-        snapped_points.loc[snapped_points["line_position"]<0.5, "node"] = closest["start_node_name"]
-        snapped_points.loc[snapped_points["line_position"]>=0.5, "node"] = closest["end_node_name"]
-        snapped_points = snapped_points[["link", "node", "snap_distance", "line_position", "geometry"]]
+        if ("start_node_name" in closest.columns) and ("end_node_name" in closest.columns):
+            snapped_points.loc[snapped_points["line_position"]<0.5, "node"] = closest["start_node_name"]
+            snapped_points.loc[snapped_points["line_position"]>=0.5, "node"] = closest["end_node_name"]
+            snapped_points = snapped_points[["link", "node", "snap_distance", "line_position", "geometry"]]
+        else:
+            snapped_points = snapped_points[["link", "snap_distance", "line_position", "geometry"]]
         snapped_points.index.name = None
         
     return snapped_points

--- a/wntr/tests/test_sim_performance.py
+++ b/wntr/tests/test_sim_performance.py
@@ -1,5 +1,6 @@
 import sys
 import unittest
+import pytest
 from os.path import abspath, dirname, join
 import threading
 import time
@@ -245,7 +246,8 @@ class TestPerformance(unittest.TestCase):
                 rel_threshold,
             )
         )
-
+    
+    @pytest.mark.time_consuming
     def test_Net6_thread_performance(self):
         """
         Test thread-safe performance of simulators
@@ -303,7 +305,8 @@ class TestPerformance(unittest.TestCase):
         t2.join()
         thr_time = time.time()-start_time
         self.assertGreaterEqual(seq_time - thr_time, -1, 'WNTR threading took 1s longer than sequential')
-
+        
+    @pytest.mark.time_consuming
     def test_Net6_mod_performance(self):
         head_diff_abs_threshold = 1e-3
         demand_diff_abs_threshold = 1e-5


### PR DESCRIPTION
## Summary
The following PR includes minor updates in preparation for the 1.0 software release.  This includes the following
- Minor update to the snap function so it will still run when start_node_name and end_node_name columns are not included in the dataframe
- Removed SWIG generated files from the coverage report
- Removed the USE_PYGEOS environment variable from wntr.__init__ because it caused some issues when running analysis. Users will get an warning message when importing geopandas that details how to set the environment variable.  This warning message should be resolved with future versions of geopandas .
- Added time_consuming flag on Net6 performance tests, this omits these tests from the quick_check build
- Updated version number and release notes

## Tests and documentation
- Updated release notes
- Included the time_consuming flag on Net6 performance tests

## Acknowledgement
By contributing to this software project, I acknowledge that I have reviewed the [software quality assurance guidelines](https://wntr.readthedocs.io/en/stable/developers.html) and that my contributions are submitted under the [Revised BSD License](https://wntr.readthedocs.io/en/stable/license.html). 
