### PR TITLE
Ensure variables and parameters keep their values when constraints are removed

### DIFF
--- a/wntr/sim/aml/aml.py
+++ b/wntr/sim/aml/aml.py
@@ -153,6 +153,7 @@ class Model(object):
         if self._refcounts[var] == 0:
             cvar = self._var_cvar_map[var]
             var._c_obj = None
+            var._value = cvar.value
             del self._refcounts[var]
             del self._var_cvar_map[var]
             self._evaluator.remove_var(cvar)
@@ -162,6 +163,7 @@ class Model(object):
         if self._refcounts[p] == 0:
             cparam = self._param_cparam_map[p]
             p._c_obj = None
+            p._value = cparam.value
             del self._refcounts[p]
             del self._param_cparam_map[p]
             self._evaluator.remove_param(cparam)


### PR DESCRIPTION
## Summary
Currently, when the number of constraints that reference a variable drops to zero, the value stored in the variable is lost. This PR fixes that.

## Acknowledgement
By contributing to this software project, I acknowledge that I have reviewed the [software quality assurance guidelines](https://wntr.readthedocs.io/en/stable/developers.html) and that my contributions are submitted under the [Revised BSD License](https://wntr.readthedocs.io/en/stable/license.html). 
