### PR TITLE
Added nodes/pipes to excluded to the skel proc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build/
 wntr.egg-info/
 dist/
 docker/
+/.vscode
 
 *.pyd
 *.pyc

--- a/documentation/morph.rst
+++ b/documentation/morph.rst
@@ -82,6 +82,7 @@ This initial set of operations can generate new branch pipes, pipes in series, a
 This cycle repeats until the network can no longer be reduced.  
 The user can specify if branch trimming, series pipe merge, and/or parallel pipe merge should be included in the skeletonization operations.  
 The user can also specify a maximum number of cycles to include in the process. 
+The user can also specify a list of nodes and pipes which should be excluded from skeletonization operations.
 
 .. only:: latex
 

--- a/wntr/epanet/io.py
+++ b/wntr/epanet/io.py
@@ -245,39 +245,30 @@ class InpFile(object):
         self.top_comments = []
         self.curves = OrderedDict()
 
-    def read(self, inp_files, wn=None):
+    @staticmethod
+    def read_sections(inp_files:list) -> tuple:
         """
-        Read an EPANET INP file and load data into a water network model object.
-        Both EPANET 2.0 and EPANET 2.2 INP file options are recognized and handled.
+        Read an EPANET INP file and return a dictionary of sections.
 
         Parameters
         ----------
         inp_files : str or list
             An EPANET INP input file or list of INP files to be combined
-        wn : WaterNetworkModel, optional
-            An optional network model to append onto; by default a new model is created.
 
         Returns
         -------
-        :class:`~wntr.network.model.WaterNetworkModel`
-            A water network model object
+        tuple
+            A tuple of two elements: a dictionary (OrderedDict) of sections, and a list of top comments
 
         """
-        if wn is None:
-            wn = WaterNetworkModel()
-        self.wn = wn
         if not isinstance(inp_files, list):
             inp_files = [inp_files]
-        wn.name = inp_files[0]
 
-        self.curves = OrderedDict()
-        self.top_comments = []
-        self.sections = OrderedDict()
+        sections = OrderedDict()
         for sec in _INP_SECTIONS:
-            self.sections[sec] = []
-        self.mass_units = None
-        self.flow_units = None
+            sections[sec] = []
 
+        top_comments = []
         for filename in inp_files:
           section = None
           lnum = 0
@@ -315,13 +306,55 @@ class InpFile(object):
                     else:
                         raise RuntimeError('%(fname)s:%(lnum)d: Invalid section "%(sec)s"' % edata)
                 elif section is None and line.startswith(';'):
-                    self.top_comments.append(line[1:])
+                    top_comments.append(line[1:])
                     continue
                 elif section is None:
                     logger.debug('Found confusing line: %s', repr(line))
                     raise RuntimeError('%(fname)s:%(lnum)d: Non-comment outside of valid section!' % edata)
                 # We have text, and we are in a section
-                self.sections[section].append((lnum, line))
+                sections[section].append((lnum, line))
+        return sections, top_comments
+
+    def read(self, inp_files, wn=None, sections=None, top_comments=None):
+        """
+        Read an EPANET INP file and load data into a water network model object.
+        Both EPANET 2.0 and EPANET 2.2 INP file options are recognized and handled.
+
+        Parameters
+        ----------
+        inp_files : str or list
+            An EPANET INP input file or list of INP files to be combined
+        wn : WaterNetworkModel, optional
+            An optional network model to append onto; by default a new model is created.
+
+        Returns
+        -------
+        :class:`~wntr.network.model.WaterNetworkModel`
+            A water network model object
+
+        """
+        if wn is None:
+            wn = WaterNetworkModel()
+        self.wn = wn
+        if not isinstance(inp_files, list):
+            inp_files = [inp_files]
+        wn.name = inp_files[0]
+
+        self.curves = OrderedDict()
+
+        self.mass_units = None
+        self.flow_units = None
+
+        if sections is None:
+            self.sections, self.top_comments = self.read_sections(inp_files)
+        else:
+            self.sections = sections
+            self.top_comments = top_comments
+            if top_comments is None:
+                self.top_comments = []
+            
+
+        assert len([key for key in self.sections.keys()]) == len(_INP_SECTIONS), 'Missing sections in INP file'
 
         # Parse each of the sections
         # The order of operations is important as certain things require prior knowledge

--- a/wntr/tests/test_morph.py
+++ b/wntr/tests/test_morph.py
@@ -315,6 +315,29 @@ class TestMorph(unittest.TestCase):
         self.assertEqual(skel_wn.num_nodes, wn.num_nodes - 17)
         self.assertEqual(skel_wn.num_links, wn.num_links - 22)
 
+    def test_skeletonize_with_excluding_nodes_and_pipes(self):
+
+        inp_file = join(datadir, "skeletonize.inp")
+        wn = wntr.network.WaterNetworkModel(inp_file)
+
+        skel_wn = wntr.morph.skeletonize(wn, 12.0 * 0.0254, use_epanet=False, nodes_to_exclude=["13"], pipes_to_exclude=["60"])
+
+        self.assertEqual(skel_wn.num_nodes, wn.num_nodes - 17)
+        self.assertEqual(skel_wn.num_links, wn.num_links - 22)
+
+        wn = wntr.network.WaterNetworkModel(inp_file)
+
+        # Change link 60 and 11 diameter to > 12, should get some results as above
+        link = wn.get_link("60")
+        link.diameter = 16 * 0.0254
+        link = wn.get_link("11")
+        link.diameter = 16 * 0.0254
+
+        skel_wn = wntr.morph.skeletonize(wn, 12.0 * 0.0254, use_epanet=False)
+
+        self.assertEqual(skel_wn.num_nodes, wn.num_nodes - 17)
+        self.assertEqual(skel_wn.num_links, wn.num_links - 22)
+
     def test_series_merge_properties(self):
 
         wn = wntr.network.WaterNetworkModel()


### PR DESCRIPTION
Provide a summary of the proposed changes, describe tests and documentation, and review the acknowledgement below. 
#347 
 
## Summary
Added nodes and links to exclude in the skelenazation process. It is handled in the same manner as the nodes and links with controls. 

## Tests and documentation
Test copied from nodes and links with controls, should have the same impact. 

Two new inputs added to the initialization of the class, so they can be extended to the nodes -links with controls. They could also be separated, but the if statements and the three separate stages are fairly complex, so I didn't want to add another `and` to it. 

Only the naming could now be improved in the if statements, instead nodes_with_controls -> nodes_to_exclude, which makes it easier to read. 
 
## Acknowledgement
By contributing to this software project, I acknowledge that I have reviewed the [software quality assurance guidelines](https://wntr.readthedocs.io/en/stable/developers.html) and that my contributions are submitted under the [Revised BSD License](https://wntr.readthedocs.io/en/stable/license.html). 
