### PR TITLE
add vertices from line string geometries when convering GIS object to…

### DIFF
--- a/wntr/gis/network.py
+++ b/wntr/gis/network.py
@@ -204,6 +204,7 @@ class WaterNetworkGIS:
                 df = element.reset_index()
                 df.rename(columns={'index':'name'}, inplace=True)
                 # TODO: create vertices from LineString geometry
+                df['vertices'] = df.apply(lambda row: list(row.geometry.coords)[1:-1], axis=1)
                 df.drop(columns=['geometry'], inplace=True)
                 wn_dict['links'].extend(df.to_dict('records'))
         

--- a/wntr/gis/network.py
+++ b/wntr/gis/network.py
@@ -203,7 +203,6 @@ class WaterNetworkGIS:
                 assert 'end_node_name' in element.columns
                 df = element.reset_index()
                 df.rename(columns={'index':'name'}, inplace=True)
-                # TODO: create vertices from LineString geometry
                 df['vertices'] = df.apply(lambda row: list(row.geometry.coords)[1:-1], axis=1)
                 df.drop(columns=['geometry'], inplace=True)
                 wn_dict['links'].extend(df.to_dict('records'))

--- a/wntr/tests/test_gis.py
+++ b/wntr/tests/test_gis.py
@@ -43,6 +43,10 @@ class TestGIS(unittest.TestCase):
         self.results = sim.run_sim()
         self.gis_data = self.wn.to_gis()
         
+        vertex_inp_file = join(datadir, "io.inp")
+        self.vertex_wn = self.wntr.network.WaterNetworkModel(vertex_inp_file)
+        self.vertex_gis_data = self.vertex_wn.to_gis()
+        
         polygon_pts = [[(25,80), (65,80), (65,60), (25,60)],
                        [(25,60), (80,60), (80,30), (25,30)],
                        [(40,50), (60,65), (60,15), (40,15)]]
@@ -102,6 +106,11 @@ class TestGIS(unittest.TestCase):
         G2 = wn2.to_graph()
         
         assert nx.is_isomorphic(G1, G2)
+        
+        # test vertices
+        vertex_wn2 = wntr.network.io.from_gis(self.vertex_gis_data)
+        for name, link in vertex_wn2.links():
+            assert link.vertices == self.vertex_wn.get_link(name).vertices
                          
     def test_intersect_points_with_polygons(self):
         


### PR DESCRIPTION
Addresses #387 
## Summary
Created vertices from linestring geometries when convering GIS object to Model object.
## Example
```
import wntr

wn_path = "io.inp"

wn = wntr.network.WaterNetworkModel(wn_path)
wn_gis = wn.to_gis()
wn_from_gis = wntr.network.io.from_gis(wn_gis)

# print vertices
for link_name in wn.link_name_list:
    link = wn.get_link(link_name)
    print(link.vertices)
# prints
# [(15.0, 5.0), (20.0, 5.0)]
# []
# []
# []
# []
# []

for link_name in wn_from_gis.link_name_list:
    link = wn_from_gis.get_link(link_name)
    print(link.vertices)
# now prints
# [(15.0, 5.0), (20.0, 5.0)]
# []
# []
# []
# []
# []
```
## Tests and documentation
Added the above example as a test. No documentation needed.
 
## Acknowledgement
By contributing to this software project, I acknowledge that I have reviewed the [software quality assurance guidelines](https://wntr.readthedocs.io/en/stable/developers.html) and that my contributions are submitted under the [Revised BSD License](https://wntr.readthedocs.io/en/stable/license.html). 
