### PR TITLE
Added setuptools and removed readthedocs config

### DIFF
--- a/documentation/installation.rst
+++ b/documentation/installation.rst
@@ -249,6 +249,7 @@ Users should have experience using Python (https://www.python.org/), including t
   http://pandas.pydata.org/
 * Matplotlib :cite:p:`hunt07`: used to produce graphics, 
   http://matplotlib.org/
+* Setuptools: used to install the WNTR package, https://setuptools.pypa.io/
   
 These packages are included in the Anaconda Python distribution.
  

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,5 +1,0 @@
-conda:
-    file: documentation/environment.yml
-python:
-    version: 3.7
-    setup_py_install: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ scipy
 networkx
 pandas
 matplotlib
+setuptools
 
 # Optional
 plotly<=5.11.0

--- a/setup.py
+++ b/setup.py
@@ -7,12 +7,9 @@ import sys
 use_swig = False
 build = True
 
-# BUILD_WNTR_EXTENSIONS is defined as an environment variable for the project at readthedocs.org
 if '--no-build' in sys.argv:
     build = False
     sys.argv.remove('--no-build')
-elif 'BUILD_WNTR_EXTENSIONS' in os.environ and os.environ['BUILD_WNTR_EXTENSIONS'].lower() == 'false':
-    build = False
 
 extension_modules = list()
 if build:
@@ -75,7 +72,7 @@ AUTHOR = 'WNTR Developers'
 MAINTAINER_EMAIL = 'kaklise@sandia.gov'
 LICENSE = 'Revised BSD'
 URL = 'https://github.com/USEPA/WNTR'
-DEPENDENCIES = ['numpy>=1.21', 'scipy', 'networkx', 'pandas', 'matplotlib']
+DEPENDENCIES = ['numpy>=1.21', 'scipy', 'networkx', 'pandas', 'matplotlib', 'setuptools']
 
 # use README file as the long description
 file_dir = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
## Summary
- Added setuptools to required packages
- Removed readthedoc.yml and readthedocs environment variable from setup.py 

## Tests and documentation
Install tested
 
## Acknowledgement
By contributing to this software project, I acknowledge that I have reviewed the [software quality assurance guidelines](https://wntr.readthedocs.io/en/stable/developers.html) and that my contributions are submitted under the [Revised BSD License](https://wntr.readthedocs.io/en/stable/license.html). 
