### PR TITLE
Fixing `plt.show()` in `plot_network` for `network_animation`

### DIFF
--- a/wntr/graphics/network.py
+++ b/wntr/graphics/network.py
@@ -47,7 +47,7 @@ def plot_network(wn, node_attribute=None, link_attribute=None, title=None,
                node_size=20, node_range=[None,None], node_alpha=1, node_cmap=None, node_labels=False,
                link_width=1, link_range=[None,None], link_alpha=1, link_cmap=None, link_labels=False,
                add_colorbar=True, node_colorbar_label='Node', link_colorbar_label='Link', 
-               directed=False, ax=None, filename=None):
+               directed=False, ax=None, show_plot=True, filename=None):
     """
     Plot network graphic
 	
@@ -126,6 +126,9 @@ def plot_network(wn, node_attribute=None, link_attribute=None, title=None,
     ax: matplotlib axes object, optional
         Axes for plotting (None indicates that a new figure with a single 
         axes will be used)
+    
+    show_plot: bool, optional
+        If True, show plot with plt.show()
     
     filename : str, optional
         Filename used to save the figure
@@ -243,7 +246,8 @@ def plot_network(wn, node_attribute=None, link_attribute=None, title=None,
     if filename:
         plt.savefig(filename)
     
-    plt.show(block=False)
+    if show_plot is True:
+        plt.show(block=False)
     
     return ax
 
@@ -769,7 +773,7 @@ def network_animation(wn, node_attribute=None, link_attribute=None, title=None,
     ax = plot_network(wn, node_attribute=initial_node_values, link_attribute=initial_link_values, title=title_name,
                node_size=node_size, node_range=node_range, node_alpha=node_alpha, node_cmap=node_cmap, node_labels=node_labels,
                link_width=link_width, link_range=link_range, link_alpha=link_alpha, link_cmap=link_cmap, link_labels=link_labels,
-               add_colorbar=add_colorbar, directed=directed, ax=ax)
+               add_colorbar=add_colorbar, directed=directed, ax=ax, show_plot=False)
         
     def update(n):
         if node_attribute is not None:
@@ -793,7 +797,7 @@ def network_animation(wn, node_attribute=None, link_attribute=None, title=None,
         ax = plot_network(wn, node_attribute=node_values, link_attribute=link_values, title=title_name,
                node_size=node_size, node_range=node_range, node_alpha=node_alpha, node_cmap=node_cmap, node_labels=node_labels,
                link_width=link_width, link_range=link_range, link_alpha=link_alpha, link_cmap=link_cmap, link_labels=link_labels,
-               add_colorbar=add_colorbar, directed=directed, ax=ax)
+               add_colorbar=add_colorbar, directed=directed, ax=ax, show_plot=False)
         
         return ax
     


### PR DESCRIPTION

## Summary
Solves issue #389 which describes problems using `wntr.graphics.network.network_animation` in Jupyter Notebooks by adding a `show_plot` parameter to the `wntr.graphics.network.plot_network` function. 

`show_plot` is set to 'True' by default on `wntr.graphics.network.plot_network`, but changed to `False` within  `wntr.graphics.network.network_animation`. This makes `network_animation` work as intended.

## Tests and documentation
None; docstring for the `show_plot` parameter of the `wntr.graphics.network.plot_network` function added
 
## Acknowledgement
By contributing to this software project, I acknowledge that I have reviewed the [software quality assurance guidelines](https://wntr.readthedocs.io/en/stable/developers.html) and that my contributions are submitted under the [Revised BSD License](https://wntr.readthedocs.io/en/stable/license.html). 
