### PR TITLE
Addressing bug caused when `units="SI"` in a call to `write_inp()`

### DIFF
--- a/wntr/epanet/io.py
+++ b/wntr/epanet/io.py
@@ -434,6 +434,8 @@ class InpFile(object):
             raise ValueError('Must pass a WaterNetworkModel object')
         if units is not None and isinstance(units, str):
             units=units.upper()
+            if units=="SI":
+                raise Exception("unit cannot be 'SI'")
             self.flow_units = FlowUnits[units]
         elif units is not None and isinstance(units, FlowUnits):
             self.flow_units = units


### PR DESCRIPTION
## Summary
Related: #409
When the `units` keyword argument is set to "SI" in `write_inp`, WNTR will generate an INP file with values in SI units and the UNITS option set to "SI". The file can be loaded into EPANET file, where the "SI" gets changed to "LPS." No other values seem to be changed in the inp file, but I think that is correct since the only difference between "SI" units and "LPS" would be flow values and maybe pressure, which are not recorded in the inp file. 

I recommend not allowing "SI" to be passed as an argument here as one potential option to address this unintuitive behavior. My PR implements a basic approach by throwing an exception when "SI" is passed. Another option would be to allow "SI", but specify to the user what is happening when they load the "SI" inpfile into EPANET (this would require first really understanding what is going on ourselves). There seems to be special behavior in EPANET when you pass "SI" as UNITS, because the same conversion to "LPS" does not occur if you load an inp file with a nonsense unit like "ASDF" into EPANET. 

## Tests and documentation
Clarification of what values should be input as `units` should be added somewhere, perhaps the docstring.
 
## Acknowledgement
By contributing to this software project, I acknowledge that I have reviewed the [software quality assurance guidelines](https://wntr.readthedocs.io/en/stable/developers.html) and that my contributions are submitted under the [Revised BSD License](https://wntr.readthedocs.io/en/stable/license.html). 
