### PR TITLE
The issue where the index_col parameter of read_shapefile can only be index.

### DIFF
--- a/wntr/gis/network.py
+++ b/wntr/gis/network.py
@@ -171,7 +171,7 @@ class WaterNetworkGIS:
         df = df_links[df_links['link_type'] == 'Valve']
         self.valves = _extract_geodataframe(df, crs, valves_as_points) 
         
-    def _create_wn(self, append=None):
+    def _create_wn(self, append=None, index_col='index'):
         """
         Create or append a WaterNetworkModel from GeoDataFrames
         
@@ -192,7 +192,7 @@ class WaterNetworkGIS:
             if element.shape[0] > 0:
                 assert (element['geometry'].geom_type).isin(['Point']).all()
                 df = element.reset_index()
-                df.rename(columns={'index':'name', 'geometry':'coordinates'}, inplace=True)
+                df.rename(columns={index_col:'name', 'geometry':'coordinates'}, inplace=True)
                 df['coordinates'] = [[x,y] for x,y in zip(df['coordinates'].x, 
                                                           df['coordinates'].y)]
                 wn_dict['nodes'].extend(df.to_dict('records'))
@@ -202,7 +202,7 @@ class WaterNetworkGIS:
                 assert 'start_node_name' in element.columns
                 assert 'end_node_name' in element.columns
                 df = element.reset_index()
-                df.rename(columns={'index':'name'}, inplace=True)
+                df.rename(columns={index_col:'name'}, inplace=True)
                 df['vertices'] = df.apply(lambda row: list(row.geometry.coords)[1:-1], axis=1)
                 df.drop(columns=['geometry'], inplace=True)
                 wn_dict['links'].extend(df.to_dict('records'))

--- a/wntr/network/io.py
+++ b/wntr/network/io.py
@@ -217,7 +217,7 @@ def from_dict(d: dict, append=None):
                     link["start_node_name"],
                     link["end_node_name"],
                     pump_type=pump_type,
-                    pump_parameter=link.setdefault("power")
+                    pump_parameter=link.setdefault("power",50.0)
                     if pump_type.lower() == "power"
                     else link.setdefault("pump_curve_name"),
                     speed=link.setdefault("base_speed", 1.0),
@@ -350,7 +350,7 @@ def from_gis(gis_data, append=None):
     if isinstance(gis_data, dict):
         gis_data = WaterNetworkGIS(gis_data)
 
-    wn = gis_data._create_wn(append=append)
+    wn = gis_data._create_wn(append=append,index_col=index_col)
     
     return wn
 
@@ -635,7 +635,7 @@ def read_shapefile(files, index_col='index', append=None):
 
     """
     gis_data = WaterNetworkGIS()
-    gis_data.read_shapefile(files, index_col='index')
+    gis_data.read_shapefile(files, index_col=index_col)
     wn = gis_data._create_wn(append=append)
 
     return wn


### PR DESCRIPTION
In previous code, the index_col parameter of the read_shapefile function in wntr.network.io seemed to only accept index (this required the element name in my shapefile to be index only). I wanted to use a field from my shapefile, such as id, to replace this index, instead of being restricted to using index. Therefore, I made some modifications and have provided some test documentation.
[test.zip](https://github.com/USEPA/WNTR/files/14920803/test.zip)

I hope to contribute to wntr, and I apologize if my idea is incorrect.
