### PR TITLE
Fix: plot_network bug due to changed networkx draw function behavior

### DIFF
--- a/wntr/graphics/network.py
+++ b/wntr/graphics/network.py
@@ -212,7 +212,7 @@ def plot_network(wn, node_attribute=None, link_attribute=None, title=None,
             nodelist=nodelist, node_color=nodecolor, node_size=node_size, 
             alpha=node_alpha, cmap=node_cmap, vmin=node_range[0], vmax = node_range[1], 
             linewidths=0, ax=ax)
-    edges = nx.draw_networkx_edges(G, pos, edgelist=linklist, 
+    edges = nx.draw_networkx_edges(G, pos, edgelist=linklist, arrows=directed,
             edge_color=linkcolor, width=link_width, alpha=link_alpha, edge_cmap=link_cmap, 
             edge_vmin=link_range[0], edge_vmax=link_range[1], ax=ax)
     if node_labels:
@@ -228,14 +228,11 @@ def plot_network(wn, node_attribute=None, link_attribute=None, title=None,
         clb = plt.colorbar(nodes, shrink=0.5, pad=0, ax=ax)
         clb.ax.set_title(node_colorbar_label, fontsize=10)
     if add_link_colorbar and link_attribute:
-        if directed:
-            vmin = min(map(abs,link_attribute.values()))
-            vmax = max(map(abs,link_attribute.values())) 
-            sm = plt.cm.ScalarMappable(cmap=link_cmap, norm=plt.Normalize(vmin=vmin, vmax=vmax))
-            sm.set_array([])
-            clb = plt.colorbar(sm, shrink=0.5, pad=0.05, ax=ax)
-        else:
-            clb = plt.colorbar(edges, shrink=0.5, pad=0.05, ax=ax)
+        vmin = min(map(abs,link_attribute.values()))
+        vmax = max(map(abs,link_attribute.values())) 
+        sm = plt.cm.ScalarMappable(cmap=link_cmap, norm=plt.Normalize(vmin=vmin, vmax=vmax))
+        sm.set_array([])
+        clb = plt.colorbar(sm, shrink=0.5, pad=0.05, ax=ax)
         clb.ax.set_title(link_colorbar_label, fontsize=10)
         
     ax.axis('off')

--- a/wntr/tests/test_graphics.py
+++ b/wntr/tests/test_graphics.py
@@ -30,16 +30,29 @@ class TestGraphics(unittest.TestCase):
         self.assertTrue(isfile(filename))
 
     def test_plot_network2(self):
-        filename = abspath(join(testdir, "plot_network2.png"))
-        if isfile(filename):
-            os.remove(filename)
-
         inp_file = join(ex_datadir, "Net3.inp")
         wn = wntr.network.WaterNetworkModel(inp_file)
 
+        # undirected
+        filename = abspath(join(testdir, "plot_network2_undirected.png"))
+        if isfile(filename):
+            os.remove(filename)
         plt.figure()
         wntr.graphics.plot_network(
             wn, node_attribute="elevation", link_attribute="length"
+        )
+        plt.savefig(filename, format="png")
+        plt.close()
+
+        self.assertTrue(isfile(filename))
+        
+        # directed
+        filename = abspath(join(testdir, "plot_network2_directed.png"))
+        if isfile(filename):
+            os.remove(filename)
+        plt.figure()
+        wntr.graphics.plot_network(
+            wn, node_attribute="elevation", link_attribute="length", directed=True
         )
         plt.savefig(filename, format="png")
         plt.close()


### PR DESCRIPTION
## Summary
A change to the behavior the networkx function `draw_networkx_edges` disrupted the colorbar code in wntr's `plot_network` function due to a mismatch in return object. 

The following code in `draw_networkx_edges` occurs in version 3.1 (probably 3.2 as well):
```
use_linecollection = not G.is_directed()
if arrows in (True, False):
    use_linecollection = not arrows
```

however this changes to the following in version 3.3:
```
if arrows is None:
    use_linecollection = not (G.is_directed() or G.is_multigraph())
else:
    if not isinstance(arrows, bool):
        raise TypeError("Argument `arrows` must be of type bool or None")
    use_linecollection = not arrows
```

The graph we use in `plot_network` is a multigraph, so `use_linecollection` now gets set to False, counter the the previous behavior. When this variable is false, the networkx function returns a list of FancyArrowPatches objects rather than a LineCollection object, which broke the way we handled colorbars. Additionally, it seems to change the plotting behavior so that the lines do not properly connect to nodes. 

In this PR, `arrows` is set to equal the argument `directed` to achieve the original behavior. The old colormap code would be fixed as well with this change, but it depended on the output type from `draw_networkx_edges` so I opted for an approach that doesn't have this dependency.

## Tests and documentation
I verified that the plots now look like they do when using networkx 3.1. I also added an extra figure to `test_plot_network2` to cover the case when `directed=True`.
 
## Acknowledgement
By contributing to this software project, I acknowledge that I have reviewed the [software quality assurance guidelines](https://wntr.readthedocs.io/en/stable/developers.html) and that my contributions are submitted under the [Revised BSD License](https://wntr.readthedocs.io/en/stable/license.html). 
