### PR TITLE
Resolved deprecation/future warnings and included GeoPandas in windows build test

### DIFF
--- a/.github/workflows/build_deploy_pages.yml
+++ b/.github/workflows/build_deploy_pages.yml
@@ -21,7 +21,7 @@ jobs:
           git remote -v
       - uses: actions/setup-python@v2
         with: 
-          python-version: '3.10'
+          python-version: '3.11'
       - name: Install package
         run: |
           pip install -e .

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -88,16 +88,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         python -m pip install -e .
-    #- name: Run Tests on Windows
-    #  if: matrix.os == 'windows-latest'
-    #  run: | # the following skips windows rst doctests that rely on geopandas (gis.rst and model_io.rst) because skipif is not working properly
-    #    coverage erase
-    #    coverage run --context=${{ matrix.os }}.py${{ matrix.python-version }} --source=wntr --omit="*/tests/*","*/sim/network_isolation/network_isolation.py","*/sim/aml/evaluator.py" -m pytest  --doctest-modules --doctest-glob="*.rst" wntr
-    #    coverage run --context=${{ matrix.os }}.py${{ matrix.python-version }} --source=wntr --omit="*/tests/*","*/sim/network_isolation/network_isolation.py","*/sim/aml/evaluator.py" --append -m pytest --doctest-glob="*.rst" --ignore-glob="*model_io.rst" --ignore-glob="*gis.rst" documentation
-    #  env:
-    #    COVERAGE_FILE: .coverage.${{ matrix.python-version }}.${{ matrix.os }}
     - name: Run Tests
-      #if: matrix.os != 'windows-latest'
       run: | 
         coverage erase
         coverage run --context=${{ matrix.os }}.py${{ matrix.python-version }} --source=wntr --omit="*/tests/*","*/sim/network_isolation/network_isolation.py","*/sim/aml/evaluator.py" -m pytest  --doctest-modules --doctest-glob="*.rst" wntr

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -88,16 +88,16 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         python -m pip install -e .
-    - name: Run Tests on Windows
-      if: matrix.os == 'windows-latest'
-      run: | # the following skips windows rst doctests that rely on geopandas (gis.rst and model_io.rst) because skipif is not working properly
-        coverage erase
-        coverage run --context=${{ matrix.os }}.py${{ matrix.python-version }} --source=wntr --omit="*/tests/*","*/sim/network_isolation/network_isolation.py","*/sim/aml/evaluator.py" -m pytest  --doctest-modules --doctest-glob="*.rst" wntr
-        coverage run --context=${{ matrix.os }}.py${{ matrix.python-version }} --source=wntr --omit="*/tests/*","*/sim/network_isolation/network_isolation.py","*/sim/aml/evaluator.py" --append -m pytest --doctest-glob="*.rst" --ignore-glob="*model_io.rst" --ignore-glob="*gis.rst" documentation
-      env:
-        COVERAGE_FILE: .coverage.${{ matrix.python-version }}.${{ matrix.os }}
+    #- name: Run Tests on Windows
+    #  if: matrix.os == 'windows-latest'
+    #  run: | # the following skips windows rst doctests that rely on geopandas (gis.rst and model_io.rst) because skipif is not working properly
+    #    coverage erase
+    #    coverage run --context=${{ matrix.os }}.py${{ matrix.python-version }} --source=wntr --omit="*/tests/*","*/sim/network_isolation/network_isolation.py","*/sim/aml/evaluator.py" -m pytest  --doctest-modules --doctest-glob="*.rst" wntr
+    #    coverage run --context=${{ matrix.os }}.py${{ matrix.python-version }} --source=wntr --omit="*/tests/*","*/sim/network_isolation/network_isolation.py","*/sim/aml/evaluator.py" --append -m pytest --doctest-glob="*.rst" --ignore-glob="*model_io.rst" --ignore-glob="*gis.rst" documentation
+    #  env:
+    #    COVERAGE_FILE: .coverage.${{ matrix.python-version }}.${{ matrix.os }}
     - name: Run Tests
-      if: matrix.os != 'windows-latest'
+      #if: matrix.os != 'windows-latest'
       run: | 
         coverage erase
         coverage run --context=${{ matrix.os }}.py${{ matrix.python-version }} --source=wntr --omit="*/tests/*","*/sim/network_isolation/network_isolation.py","*/sim/aml/evaluator.py" -m pytest  --doctest-modules --doctest-glob="*.rst" wntr

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -5,9 +5,9 @@ name: build
 
 on:
   push:
-    branches: [ main, dev ]
+    branches: [ main, dev, build ]
   pull_request:
-    branches: [ main, dev ]
+    branches: [ main, dev, build ]
   schedule:
     - cron: '0 0 1 * *'
 

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -5,9 +5,9 @@ name: build
 
 on:
   push:
-    branches: [ main, dev, build ]
+    branches: [ main, dev ]
   pull_request:
-    branches: [ main, dev, build ]
+    branches: [ main, dev ]
   schedule:
     - cron: '0 0 1 * *'
 

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -64,7 +64,7 @@ jobs:
     - name: Install wntr
       run: |
         python -m pip install --upgrade pip
-        pip install wheel numpy scipy networkx pandas matplotlib
+        pip install wheel numpy scipy networkx pandas matplotlib setuptools
         pip install --no-index --pre --find-links=. wntr
     - name: Usage of wntr
       run: |

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -41,8 +41,7 @@ jobs:
         name: wntr_${{ matrix.python-version }}_${{ matrix.os }}.whl
         path: dist/wntr*
 
-  test:
-    name: Test install and usage of wntr
+  install_import:
     needs: build
     runs-on: ${{ matrix.os }}
     strategy:
@@ -70,7 +69,7 @@ jobs:
       run: |
         python -c "import wntr"
 
-  create_coverage_reports:
+  pytest_coverage:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -103,7 +102,7 @@ jobs:
         path: .coverage.${{ matrix.python-version }}.${{ matrix.os }}
 
   combine_reports:
-    needs: [ create_coverage_reports ]
+    needs: [ pytest_coverage ]
     runs-on: ubuntu-latest
     steps:
     - name: Set up Python 
@@ -148,7 +147,7 @@ jobs:
         path: htmlcov
 
   combine_reports_upload_coveralls:
-    needs: [ create_coverage_reports ]
+    needs: [ pytest_coverage ]
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         os: [windows-latest, macOS-latest, ubuntu-latest] 
     steps:
     - uses: actions/checkout@v2
@@ -47,7 +47,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         os: [windows-latest, macOS-latest, ubuntu-latest]    
     steps:
     - name: Set up Python 
@@ -74,7 +74,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.9', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         os: [windows-latest, macOS-latest, ubuntu-latest]
     steps:
     - uses: actions/checkout@v2
@@ -109,7 +109,7 @@ jobs:
     - name: Set up Python 
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.11
     - uses: actions/checkout@v2
     - name: Install coverage
       run: |
@@ -155,7 +155,7 @@ jobs:
     - name: Set up Python 
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.11
     - uses: actions/checkout@v2
     - name: Install coverage
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.11'
       - name: build the sdist
         run: |
           python -m pip install --upgrade build

--- a/documentation/disaster_models.rst
+++ b/documentation/disaster_models.rst
@@ -93,7 +93,8 @@ The earthquake properties can be plotted on the network using the following exam
 
     >>> plt.tight_layout()
     >>> plt.savefig('network_pga.png', dpi=300)
-    
+    >>> plt.close()
+
 .. _fig-network:
 .. figure:: figures/network_pga.png
    :width: 640

--- a/documentation/environment.yml
+++ b/documentation/environment.yml
@@ -1,6 +1,6 @@
 name: wntr
 dependencies:
-    - python=3.10
+    - python=3.11
     - numpy
     - scipy
     - networkx

--- a/documentation/fragility.rst
+++ b/documentation/fragility.rst
@@ -54,6 +54,7 @@ The following example defines a fragility curve with two damage states: Minor da
     
     >>> plt.tight_layout()
     >>> plt.savefig('fragility_curve.png', dpi=300)
+    >>> plt.close()
 
 :numref:`fig-fragility` illustrates the fragility curve as a function of peak ground acceleration.  
 For example, if the peak ground acceleration is 0.3 at 
@@ -108,7 +109,8 @@ To plot the damage state on the network, the state (i.e., Major) can be converte
     
     >>> plt.tight_layout()
     >>> plt.savefig('damage_state.png', dpi=300)
-    
+    >>> plt.close()
+
 .. _fig-damage-state:
 .. figure:: figures/damage_state.png
    :width: 640

--- a/documentation/gis.rst
+++ b/documentation/gis.rst
@@ -427,6 +427,7 @@ the hydrants snapped to the junctions in Net1.
     >>> bounds = ax.axis('equal')
     >>> plt.tight_layout()
     >>> plt.savefig('snap_points.png', dpi=300)
+    >>> plt.close()
 
 .. _fig-snap-points:
 .. figure:: figures/snap_points.png
@@ -511,6 +512,7 @@ illustrates the valve layer created by snapping points to lines in Net1.
     >>> bounds = ax.axis('equal')
     >>> plt.tight_layout()
     >>> plt.savefig('snap_lines.png', dpi=300)
+    >>> plt.close()
 
 .. _fig-snap-lines:
 .. figure:: figures/snap_lines.png
@@ -615,7 +617,8 @@ The pipes are colored based upon their maximum earthquake probability.
     >>> bounds = ax.axis('equal')
     >>> plt.tight_layout()
     >>> plt.savefig('intersect_earthquake.png', dpi=300)
-	
+    >>> plt.close()
+
 .. _fig-intersect-earthquake:
 .. figure:: figures/intersect_earthquake.png
    :width: 640
@@ -699,6 +702,7 @@ The pipes are colored based upon their weighted mean landslide probability.
     >>> bounds = ax.axis('equal')
     >>> plt.tight_layout()
     >>> plt.savefig('intersect_landslide.png', dpi=300)
+    >>> plt.close()
 
 .. _fig-intersect-landslide:
 .. figure:: figures/intersect_landslide.png
@@ -807,6 +811,7 @@ the census tracts (polygons) is different than the junction and pipe attributes.
     >>> bounds = ax.axis('equal')
     >>> plt.tight_layout()
     >>> plt.savefig('intersect_demographics.png', dpi=300)
+    >>> plt.close()
 
 .. _fig-intersect-demographics:
 .. figure:: figures/intersect_demographics.png

--- a/documentation/graphics.rst
+++ b/documentation/graphics.rst
@@ -63,7 +63,8 @@ which can be further customized by the user.
 
     >>> plt.tight_layout()
     >>> plt.savefig('plot_basic_network.png', dpi=300)
-    
+    >>> plt.close()
+
 .. _fig-network-2:
 .. figure:: figures/plot_basic_network.png
    :width: 640
@@ -118,7 +119,8 @@ See https://matplotlib.org for more colormap options.
 
     >>> plt.tight_layout()
     >>> plt.savefig('plot_subplot_basic_network.png', dpi=300)
-    
+    >>> plt.close()
+
 .. _fig-network-3:
 .. figure:: figures/plot_subplot_basic_network.png
    :width: 800
@@ -267,7 +269,8 @@ The following example uses simulation results from above, and converts the graph
 
     >>> plt.tight_layout()
     >>> plt.savefig('plot_pump_curve.png', dpi=300)
-	
+    >>> plt.close()
+
 .. _fig-interactive-timeseries:
 .. figure:: figures/interactive_timeseries.png
    :width: 640
@@ -331,7 +334,8 @@ The following example plots a pump curve (:numref:`fig-pump`).
 
     >>> plt.tight_layout()
     >>> plt.savefig('plot_pump_curve.png', dpi=300)
-    
+    >>> plt.close()
+
 .. _fig-pump:
 .. figure:: figures/plot_pump_curve.png
    :width: 640
@@ -380,7 +384,8 @@ level of the tank is included in the figure.
 
     >>> plt.tight_layout()
     >>> plt.savefig('plot_tank_volume_curve.png', dpi=300)
-    
+    >>> plt.close()
+
 .. _fig-tank:
 .. figure:: figures/plot_tank_volume_curve.png
    :width: 800
@@ -420,6 +425,7 @@ The valves and valve segments are plotted on the network (:numref:`fig-valve_seg
 
     >>> plt.tight_layout()
     >>> plt.savefig('plot_valve_segment.png', dpi=300)
+    >>> plt.close()
 
 .. _fig-valve_segment:
 .. figure:: figures/plot_valve_segment.png
@@ -447,7 +453,8 @@ valves surrounding each valve is plotted on the network
 
     >>> plt.tight_layout()
     >>> plt.savefig('plot_valve_segment_attributes.png', dpi=300)
-    
+    >>> plt.close()
+
 .. _fig-valve_segment_attributes:
 .. figure:: figures/plot_valve_segment_attributes.png
    :width: 640

--- a/documentation/installation.rst
+++ b/documentation/installation.rst
@@ -8,7 +8,7 @@ Installation
 ======================================
 .. include:: <isonum.txt>
 
-WNTR requires 64-bit Python (tested on versions 3.9, 3.10, and 3.11) along with several 
+WNTR requires 64-bit Python (tested on versions 3.9, 3.10, 3.11, and 3.12) along with several 
 Python package dependencies. 
 See :ref:`requirements` and :ref:`optional_dependencies` for more information.
 WNTR can be installed as a Python package as briefly described below. 
@@ -58,7 +58,7 @@ Step 1: Setup the Python environment
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 	Python can be installed on Windows, Linux, and Mac OS X operating systems.
-	WNTR requires 64-bit Python (tested on versions 3.9, 3.10, and 3.11) along with several Python package dependencies.
+	WNTR requires 64-bit Python (tested on versions 3.9, 3.10, 3.11, and 3.12) along with several Python package dependencies.
 	Python distributions, such as Anaconda, are recommended to manage 
 	the Python environment.  Anaconda can be downloaded from https://www.anaconda.com/products/individual.
 	Additional instructions for setting up a Python environment independent of Anaconda are available at https://docs.python.org/.
@@ -240,7 +240,7 @@ To test WNTR, developers can run software tests locally using the following comm
 Requirements
 -------------
 
-Requirements for WNTR include 64-bit Python (tested on versions 3.9, 3.10, and 3.11) along with several Python packages. 
+Requirements for WNTR include 64-bit Python (tested on versions 3.9, 3.10, 3.11, and 3.12) along with several Python packages. 
 Users should have experience using Python (https://www.python.org/), including the installation of additional Python packages. The following Python packages are required:
 
 * NumPy :cite:p:`vacv11`: used to support large, multi-dimensional arrays and matrices, 

--- a/documentation/installation.rst
+++ b/documentation/installation.rst
@@ -285,8 +285,7 @@ To install optional dependencies, run::
 .. note:: 
    Proper installation of geopandas requires installing several geopandas dependencies, including 
    fiona, pyproj, and shapely.  See https://geopandas.org/en/stable/getting_started/install.html for more information.
-   On Linux and Mac OS X, installing geopandas through the conda-forge channel will install the dependencies.
-   On Windows, the dependencies must be installed manually, see https://geoffboeing.com/2014/09/using-geopandas-windows/ for more information.
+   On Windows, the dependencies can be installed manually, see https://geoffboeing.com/2014/09/using-geopandas-windows/ for more information.
    
 .. The following is not shown in the UM
    WNTR includes a beta version of a Pyomo hydraulic simulator which requires installing 

--- a/documentation/layers.rst
+++ b/documentation/layers.rst
@@ -80,6 +80,7 @@ The valve layer can be included in water network graphics (:numref:`fig-random-v
 
     >>> plt.tight_layout()
     >>> plt.savefig('random_valve_layer.png', dpi=300)
+    >>> plt.close()
 
 .. _fig-random-valve-layer:
 .. figure:: figures/random_valve_layer.png
@@ -104,6 +105,7 @@ The valve layer can be included in water network graphics (:numref:`fig-strategi
 
     >>> plt.tight_layout()
     >>> plt.savefig('strategic_valve_layer.png', dpi=300)
+    >>> plt.close()
 
 .. _fig-strategic-valve-layer:
 .. figure:: figures/strategic_valve_layer.png

--- a/documentation/morph.rst
+++ b/documentation/morph.rst
@@ -147,7 +147,8 @@ approximately 3000 to approximately 1000 (:numref:`fig-skel-example`).
     
     >>> plt.tight_layout()
     >>> plt.savefig('skel_example.png', dpi=300)
-    
+    >>> plt.close()
+
 .. _fig-skel-example:
 .. figure:: figures/skel_example.png
    :width: 800
@@ -202,7 +203,8 @@ Pressure differences are very small in this example.
     
     >>> plt.tight_layout()
     >>> plt.savefig('skel_hydraulics.png', dpi=300)
-    
+    >>> plt.close()
+
 .. _fig-skel-hydraulics:
 .. figure:: figures/skel_hydraulics.png
    :width: 640

--- a/documentation/resultsobject.rst
+++ b/documentation/resultsobject.rst
@@ -153,7 +153,8 @@ Data can be plotted as a time series, as shown in :numref:`fig-plot-timeseries`:
 
     >>> plt.tight_layout()
     >>> plt.savefig('plot_timeseries.png', dpi=300)
-    
+    >>> plt.close()
+
 .. _fig-plot-timeseries:
 .. figure:: figures/plot_timeseries.png
    :width: 640
@@ -182,7 +183,8 @@ plotted in a similar manner.
 
     >>> plt.tight_layout()
     >>> plt.savefig('plot_network.png', dpi=300)
-    
+    >>> plt.close()
+
 .. _fig-plot-network:
 .. figure:: figures/plot_network.png
    :width: 640

--- a/documentation/whatsnew.rst
+++ b/documentation/whatsnew.rst
@@ -1,6 +1,10 @@
 Release notes
 ================
 
+.. _whatsnew_120:
+
+.. include:: whatsnew/v1.2.0.rst
+
 .. _whatsnew_110:
 
 .. include:: whatsnew/v1.1.0.rst

--- a/documentation/whatsnew/v1.2.0.rst
+++ b/documentation/whatsnew/v1.2.0.rst
@@ -1,0 +1,11 @@
+v1.2.0 (main)
+---------------------------------------------------
+WNTR version 1.2.0 includes the following updates:
+
+* Added basic and geospatial jupyter notebook demos, updated documentation, dropped Python 3.7 and 3.8 from testing https://github.com/USEPA/WNTR/pull/419
+* Fix: plot_network bug due to changed networkx draw function behavior https://github.com/USEPA/WNTR/pull/417
+* Fix: Addressing bug caused when units="SI" in a call to write_inp() https://github.com/USEPA/WNTR/pull/410
+* Added EpanetException class and subclasses that allow for cleaner error reporting during IO https://github.com/USEPA/WNTR/pull/381
+* Added google analytics key https://github.com/USEPA/WNTR/pull/406
+* Documentation updates to install WNTR without Anaconda https://github.com/USEPA/WNTR/pull/403
+* Added setuptools and removed readthedocs config https://github.com/USEPA/WNTR/pull/396

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ matplotlib
 setuptools
 
 # Optional
-plotly<=5.11.0
+plotly
 folium
 utm
 openpyxl

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,8 +11,8 @@ plotly<=5.11.0
 folium
 utm
 openpyxl
-geopandas; sys_platform == "darwin" or sys_platform == "linux"
-rtree; sys_platform == "darwin" or sys_platform == "linux"
+geopandas
+rtree
 
 # Documentation
 sphinx

--- a/wntr/epanet/io.py
+++ b/wntr/epanet/io.py
@@ -2683,7 +2683,7 @@ class BinFile(object):
             """
             logger.debug('... read energy data ...')
             for i in range(npumps):
-                pidx = int(np.fromfile(fin,dtype=np.int32, count=1))
+                pidx = int(np.fromfile(fin,dtype=np.int32, count=1)[0])
                 energy = np.fromfile(fin, dtype=np.dtype(ftype), count=6)
                 self.save_energy_line(pidx, linknames[pidx-1], energy)
             peakenergy = np.fromfile(fin, dtype=np.dtype(ftype), count=1)

--- a/wntr/gis/geospatial.py
+++ b/wntr/gis/geospatial.py
@@ -256,7 +256,7 @@ def intersect(A, B, B_value=None, include_background=False, background_value=0):
         
         for i in B.index:
             B_geom = gpd.GeoDataFrame(B.loc[[i],:], crs=B.crs)
-            val = float(B_geom[B_value])
+            val = float(B_geom.iloc[0][B_value])
             A_subset = A.loc[stats['intersections'].apply(lambda x: i in x),:]
             #print(i, lines_subset)
             A_clip = gpd.clip(A_subset, B_geom) 

--- a/wntr/metrics/topographic.py
+++ b/wntr/metrics/topographic.py
@@ -269,7 +269,7 @@ def valve_segments(G, valve_layer):
         # and label link and unvalved node together
         if link_valves.shape[0] == 1:
             both_node_names = [node1_name, node2_name]
-            valved_node_name = link_valves.iloc[0][1]
+            valved_node_name = link_valves.iloc[0]['node']
             both_node_names.remove(valved_node_name)
             unvalved_node_name = both_node_names[0]
             unvalved_node_index = all_names.index('N_'+unvalved_node_name)
@@ -281,7 +281,7 @@ def valve_segments(G, valve_layer):
                 seg_label[link_index] = seg_label[unvalved_node_index]
 
         # Links with link_valves.size == 2 are already labelled (isolated link)
-        elif link_valves.shape[0] ==2:
+        elif link_valves.shape[0] == 2:
             continue
         else:
             raise Exception("Each link should have a maximum of two valves.")

--- a/wntr/metrics/topographic.py
+++ b/wntr/metrics/topographic.py
@@ -232,9 +232,7 @@ def valve_segments(G, valve_layer):
             seg_label[all_names.index(node_name)] = seg_index
     
     # Collect valved link names
-    valved_link_names = []    
-    for i, row in valve_layer.iterrows():
-        valved_link_names.append(row[0])
+    valved_link_names = list(valve_layer['link'].unique()) 
 
     # Remove valved edges from G
     valved_edges = []

--- a/wntr/network/model.py
+++ b/wntr/network/model.py
@@ -1304,8 +1304,8 @@ class WaterNetworkModel(AbstractModel):
 
             # Extract the node demand pattern and resample to match the pattern timestep
             demand_pattern = demand.loc[:, junc_name]
-            demand_pattern.index = pd.TimedeltaIndex(demand_pattern.index, "s")
-            resample_offset = str(int(self.options.time.pattern_timestep)) + "S"
+            demand_pattern.index = pd.to_timedelta(demand_pattern.index, "s")
+            resample_offset = str(int(self.options.time.pattern_timestep)) + "s"
             demand_pattern = demand_pattern.resample(resample_offset).mean() / self.options.hydraulic.demand_multiplier
 
             # Add the pattern


### PR DESCRIPTION
## Summary
The following PR includes minor updates to resolve deprecation and future warnings.  The windows build test now includes GeoPandas, which can be installed through pip. Plotly is no longer set to <=5.11.0. Scipy is still set to <1.13.0.

## Tests and documentation
Installation instructions updated for GeoPandas
 
## Acknowledgement
By contributing to this software project, I acknowledge that I have reviewed the [software quality assurance guidelines](https://wntr.readthedocs.io/en/stable/developers.html) and that my contributions are submitted under the [Revised BSD License](https://wntr.readthedocs.io/en/stable/license.html). 
