### PR TITLE
Workflow and testing fixes

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -48,7 +48,8 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12']
-        os: [windows-latest, macOS-13, ubuntu-latest]    
+        os: [windows-latest, macOS-13, ubuntu-latest]
+      fail-fast: false
     steps:
     - name: Set up Python 
       uses: actions/setup-python@v4
@@ -76,6 +77,7 @@ jobs:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12']
         os: [windows-latest, macOS-13, ubuntu-latest]
+      fail-fast: false
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -59,14 +59,10 @@ jobs:
       uses: actions/download-artifact@v3
       with:
         name: wntr_${{ matrix.python-version }}_${{ matrix.os }}.whl
-    # - name: Discover
-    #   run: |
-    #     ls .
     - name: Install wntr
       run: |
         python -m pip install --upgrade pip
-        # pip install wheel numpy scipy networkx pandas matplotlib setuptools
-        pip install --no-index --pre --find-links=. wntr
+        pip install wntr_${{ matrix.python-version }}_${{ matrix.os }}.whl
     - name: Usage of wntr
       run: |
         python -c "import wntr"

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -18,7 +18,8 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12']
-        os: [windows-latest, macOS-13, ubuntu-latest] 
+        os: [windows-latest, macOS-13, ubuntu-latest]
+      fail-fast: false
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -10,6 +10,7 @@ on:
     branches: [ main, dev ]
   schedule:
     - cron: '0 0 1 * *'
+  workflow_dispatch:
 
 jobs:
 
@@ -94,6 +95,7 @@ jobs:
         coverage run --context=${{ matrix.os }}.py${{ matrix.python-version }} --source=wntr --omit="*/tests/*","*/sim/network_isolation/network_isolation.py","*/sim/aml/evaluator.py" --append -m pytest --doctest-glob="*.rst" documentation
       env:
         COVERAGE_FILE: .coverage.${{ matrix.python-version }}.${{ matrix.os }}
+      continue-on-error: true
         
     - name: Save coverage
       uses: actions/upload-artifact@v2

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -62,7 +62,8 @@ jobs:
     - name: Install wntr
       run: |
         python -m pip install --upgrade pip
-        pip install wntr_${{ matrix.python-version }}_${{ matrix.os }}.whl
+        pip install wheel numpy>=1.2.1,<2.0 scipy networkx pandas matplotlib setuptools
+        pip install --no-index --pre --find-links=. wntr
     - name: Usage of wntr
       run: |
         python -c "import wntr"

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12']
-        os: [windows-latest, macOS-latest, ubuntu-latest] 
+        os: [windows-latest, macOS-13, ubuntu-latest] 
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12']
-        os: [windows-latest, macOS-latest, ubuntu-latest]    
+        os: [windows-latest, macOS-13, ubuntu-latest]    
     steps:
     - name: Set up Python 
       uses: actions/setup-python@v4
@@ -68,14 +68,13 @@ jobs:
     - name: Usage of wntr
       run: |
         python -c "import wntr"
-      continue-on-error: true
 
   pytest_coverage:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12']
-        os: [windows-latest, macOS-latest, ubuntu-latest]
+        os: [windows-latest, macOS-13, ubuntu-latest]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -95,7 +94,6 @@ jobs:
         coverage run --context=${{ matrix.os }}.py${{ matrix.python-version }} --source=wntr --omit="*/tests/*","*/sim/network_isolation/network_isolation.py","*/sim/aml/evaluator.py" --append -m pytest --doctest-glob="*.rst" documentation
       env:
         COVERAGE_FILE: .coverage.${{ matrix.python-version }}.${{ matrix.os }}
-      continue-on-error: true
         
     - name: Save coverage
       uses: actions/upload-artifact@v2

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -10,7 +10,6 @@ on:
     branches: [ main, dev ]
   schedule:
     - cron: '0 0 1 * *'
-  workflow_dispatch:
 
 jobs:
 
@@ -69,6 +68,7 @@ jobs:
     - name: Usage of wntr
       run: |
         python -c "import wntr"
+      continue-on-error: true
 
   pytest_coverage:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Install wntr
       run: |
         python -m pip install --upgrade pip
-        pip install wheel numpy>=1.2.1,<2.0 scipy networkx pandas matplotlib setuptools
+        pip install wheel "numpy>=1.2.1,<2.0" scipy networkx pandas matplotlib setuptools
         pip install --no-index --pre --find-links=. wntr
     - name: Usage of wntr
       run: |

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -65,7 +65,7 @@ jobs:
     - name: Install wntr
       run: |
         python -m pip install --upgrade pip
-        pip install wheel numpy scipy networkx pandas matplotlib setuptools
+        # pip install wheel numpy scipy networkx pandas matplotlib setuptools
         pip install --no-index --pre --find-links=. wntr
     - name: Usage of wntr
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-2019, macOS-11, ubuntu-20.04] 
+        os: [windows-2019, macOS-13, ubuntu-20.04] 
     steps:
     - uses: actions/checkout@v3
     - name: Build wheels

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "numpy>=1.21"]
+requires = ["setuptools", "numpy>=1.21, <2.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "numpy>=1.21, <2.0"]
+requires = ["setuptools", "numpy>=1.21,<2.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Required
-numpy>=1.21
+numpy>=1.21, <2.0
 scipy<1.13.0
 networkx
 pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Required
-numpy>=1.21, <2.0
+numpy>=1.21,<2.0
 scipy<1.13.0
 networkx
 pandas

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ AUTHOR = 'WNTR Developers'
 MAINTAINER_EMAIL = 'kaklise@sandia.gov'
 LICENSE = 'Revised BSD'
 URL = 'https://github.com/USEPA/WNTR'
-DEPENDENCIES = ['numpy>=1.21', 'scipy', 'networkx', 'pandas', 'matplotlib', 'setuptools']
+DEPENDENCIES = ['numpy>=1.21, <2.0', 'scipy', 'networkx', 'pandas', 'matplotlib', 'setuptools']
 
 # use README file as the long description
 file_dir = os.path.abspath(os.path.dirname(__file__))

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ AUTHOR = 'WNTR Developers'
 MAINTAINER_EMAIL = 'kaklise@sandia.gov'
 LICENSE = 'Revised BSD'
 URL = 'https://github.com/USEPA/WNTR'
-DEPENDENCIES = ['numpy>=1.21, <2.0', 'scipy', 'networkx', 'pandas', 'matplotlib', 'setuptools']
+DEPENDENCIES = ['numpy>=1.21,<2.0', 'scipy', 'networkx', 'pandas', 'matplotlib', 'setuptools']
 
 # use README file as the long description
 file_dir = os.path.abspath(os.path.dirname(__file__))

--- a/wntr/tests/test_network.py
+++ b/wntr/tests/test_network.py
@@ -142,7 +142,7 @@ class TestNetworkMethods(unittest.TestCase):
         self.assertEqual(l.name, "p1")
         self.assertEqual(l.start_node_name, "j1")
         self.assertEqual(l.end_node_name, "j2")
-        self.assertEqual(l.initial_status, self.wntr.network.LinkStatus.opened)
+        self.assertEqual(l.initial_status, self.wntr.network.LinkStatus.Opened)
         self.assertEqual(l.length, 1000.0)
         self.assertEqual(l.diameter, 1.0)
         self.assertEqual(l.roughness, 100.0)
@@ -255,7 +255,7 @@ class TestNetworkMethods(unittest.TestCase):
         wn = self.wntr.network.WaterNetworkModel(inp_file)
 
         control_action = self.wntr.network.ControlAction(
-            wn.get_link("21"), "status", self.wntr.network.LinkStatus.opened
+            wn.get_link("21"), "status", self.wntr.network.LinkStatus.Opened
         )
         control = self.wntr.network.controls.Control._conditional_control(
             wn.get_node("2"), "head", np.greater_equal, 10.0, control_action

--- a/wntr/tests/test_network_controls.py
+++ b/wntr/tests/test_network_controls.py
@@ -102,13 +102,13 @@ class TestTimeControls(unittest.TestCase):
                     link_res["flowrate"].at[t, "pipe2"], 150 / 3600.0
                 )
                 self.assertEqual(
-                    link_res["status"].at[t, "pipe2"], self.wntr.network.LinkStatus.open
+                    link_res["status"].at[t, "pipe2"], self.wntr.network.LinkStatus.Open
                 )
             else:
                 self.assertAlmostEqual(link_res["flowrate"].at[t, "pipe2"], 0.0)
                 self.assertEqual(
                     link_res["status"].at[t, "pipe2"],
-                    self.wntr.network.LinkStatus.closed,
+                    self.wntr.network.LinkStatus.Closed,
                 )
 
 
@@ -147,14 +147,14 @@ class TestConditionalControls(unittest.TestCase):
                 self.assertAlmostEqual(link_res["flowrate"].at[t, "pump1"], 0.0)
                 self.assertEqual(
                     link_res["status"].at[t, "pump1"],
-                    self.wntr.network.LinkStatus.closed,
+                    self.wntr.network.LinkStatus.Closed,
                 )
                 count += 1
             else:
                 self.assertGreaterEqual(link_res["flowrate"].at[t, "pump1"], 0.0001)
                 self.assertEqual(
                     link_res["status"].loc[t, "pump1"],
-                    self.wntr.network.LinkStatus.open,
+                    self.wntr.network.LinkStatus.Open,
                 )
         self.assertEqual(activated_flag, True)
         self.assertGreaterEqual(count, 2)
@@ -229,20 +229,20 @@ class TestConditionalControls(unittest.TestCase):
                 self.assertGreaterEqual(results.link["flowrate"].at[t, "pipe1"], 0.002)
                 self.assertEqual(
                     results.link["status"].at[t, "pipe1"],
-                    self.wntr.network.LinkStatus.open,
+                    self.wntr.network.LinkStatus.Open,
                 )
                 count += 1
             else:
                 self.assertAlmostEqual(results.link["flowrate"].at[t, "pipe1"], 0.0)
                 self.assertEqual(
                     results.link["status"].at[t, "pipe1"],
-                    self.wntr.network.LinkStatus.closed,
+                    self.wntr.network.LinkStatus.Closed,
                 )
         self.assertEqual(activated_flag, True)
         self.assertGreaterEqual(count, 2)
         self.assertEqual(
             results.link["status"].at[results.link["status"].index[0], "pipe1"],
-            self.wntr.network.LinkStatus.closed,
+            self.wntr.network.LinkStatus.Closed,
         )  # make sure the pipe starts closed
         self.assertLessEqual(
             results.node["pressure"].at[results.node["pressure"].index[0], "tank1"],
@@ -277,7 +277,7 @@ class TestTankControls(unittest.TestCase):
                 self.assertLessEqual(results.link["flowrate"].at[t, "pipe1"], 0.0)
                 self.assertEqual(
                     results.link["status"].at[t, "pipe1"],
-                    self.wntr.network.LinkStatus.closed,
+                    self.wntr.network.LinkStatus.Closed,
                 )
                 tank_level_dropped_flag = True
         self.assertEqual(tank_level_dropped_flag, True)
@@ -384,7 +384,7 @@ class TestControlCombinations(unittest.TestCase):
         inp_file = join(test_datadir, "control_comb.inp")
         wn = self.wntr.network.WaterNetworkModel(inp_file)
         control_action = self.wntr.network.ControlAction(
-            wn.get_link("pipe1"), "status", self.wntr.network.LinkStatus.opened
+            wn.get_link("pipe1"), "status", self.wntr.network.LinkStatus.Opened
         )
         control = self.wntr.network.controls.Control._time_control(
             wn, 6 * 3600, "SIM_TIME", False, control_action
@@ -432,9 +432,9 @@ class TestControlCombinations(unittest.TestCase):
         tank1.init_level = 40.0
         tank1._head = tank1.elevation + 40.0
         pipe1 = wn.get_link("pipe1")
-        pipe1._user_status = self.wntr.network.LinkStatus.opened
+        pipe1._user_status = self.wntr.network.LinkStatus.Opened
         control_action = self.wntr.network.ControlAction(
-            wn.get_link("pipe1"), "status", self.wntr.network.LinkStatus.opened
+            wn.get_link("pipe1"), "status", self.wntr.network.LinkStatus.Opened
         )
         control = self.wntr.network.controls.Control._time_control(
             wn, 19 * 3600, "SIM_TIME", False, control_action
@@ -482,9 +482,9 @@ class TestControlCombinations(unittest.TestCase):
         tank1.init_level = 40.0
         tank1._head = tank1.elevation + 40.0
         pipe1 = wn.get_link("pipe1")
-        pipe1._user_status = self.wntr.network.LinkStatus.opened
+        pipe1._user_status = self.wntr.network.LinkStatus.Opened
         control_action = self.wntr.network.ControlAction(
-            wn.get_link("pipe1"), "status", self.wntr.network.LinkStatus.opened
+            wn.get_link("pipe1"), "status", self.wntr.network.LinkStatus.Opened
         )
         control = self.wntr.network.controls.Control._time_control(
             wn, 5 * 3600, "SIM_TIME", False, control_action


### PR DESCRIPTION
## Summary

- Adding a restriction on numpy dependency to be less than 2.0 (AML is not 2.0 compatible yet).
- Changing the macOS version we use in workflow from `macOS-latest` to `macOS-13` because tests fail on ARM due to a lack of EPANET binaries for this architecture.
- Addressed a testing error that occurs on Python 3.12.4. The behavior of a private variable for enums appears to have changed, so we can no longer use all uppercase or all lowercase versions of member names to access members from an enum.
- Changed `fail-fast` to false in multiple jobs in the `build` workflow. This means that jobs will continue running even when one fails.

## Tests and documentation
None added.
 
## Acknowledgement
By contributing to this software project, I acknowledge that I have reviewed the [software quality assurance guidelines](https://wntr.readthedocs.io/en/stable/developers.html) and that my contributions are submitted under the [Revised BSD License](https://wntr.readthedocs.io/en/stable/license.html). 
