### PR TITLE
Fix #433 - Gis files written with column title 'name'

### DIFF
--- a/documentation/gis.rst
+++ b/documentation/gis.rst
@@ -119,6 +119,7 @@ For example, the junctions GeoDataFrame contains the following information:
     12    Junction    213.360        5.000e-04  POINT (50.00000 70.00000)
     13    Junction    211.836        5.000e-04  POINT (70.00000 70.00000)
     21    Junction    213.360        5.000e-04  POINT (30.00000 40.00000)
+
 Each GeoDataFrame contains attributes and geometry:
 
 Attributes
@@ -335,21 +336,21 @@ and then translates the GeoDataFrames coordinates to EPSG:3857.
     >>> print(wn_gis.junctions.head())
          node_type  elevation  initial_quality                   geometry
     name                                                                 
-    10    Junction    216.408           0.0005  POINT (20.00000 70.00000)
-    11    Junction    216.408           0.0005  POINT (30.00000 70.00000)
-    12    Junction    213.360           0.0005  POINT (50.00000 70.00000)
-    13    Junction    211.836           0.0005  POINT (70.00000 70.00000)
-    21    Junction    213.360           0.0005  POINT (30.00000 40.00000)
+    10    Junction    216.408        5.000e-04  POINT (20.00000 70.00000)
+    11    Junction    216.408        5.000e-04  POINT (30.00000 70.00000)
+    12    Junction    213.360        5.000e-04  POINT (50.00000 70.00000)
+    13    Junction    211.836        5.000e-04  POINT (70.00000 70.00000)
+    21    Junction    213.360        5.000e-04  POINT (30.00000 40.00000)
 
     >>> wn_gis.to_crs('EPSG:3857')
     >>> print(wn_gis.junctions.head())
          node_type  elevation  initial_quality                          geometry
     name                                                                        
-    10    Junction    216.408           0.0005  POINT (2226389.816 11068715.659)
-    11    Junction    216.408           0.0005  POINT (3339584.724 11068715.659)
-    12    Junction    213.360           0.0005  POINT (5565974.540 11068715.659)
-    13    Junction    211.836           0.0005  POINT (7792364.356 11068715.659)
-    21    Junction    213.360           0.0005   POINT (3339584.724 4865942.280)
+    10    Junction    216.408        5.000e-04  POINT (2226389.816 11068715.659)
+    11    Junction    216.408        5.000e-04  POINT (3339584.724 11068715.659)
+    12    Junction    213.360        5.000e-04  POINT (5565974.540 11068715.659)
+    13    Junction    211.836        5.000e-04  POINT (7792364.356 11068715.659)
+    21    Junction    213.360        5.000e-04   POINT (3339584.724 4865942.280)
 
 Snap point geometries to the nearest point or line
 ----------------------------------------------------

--- a/documentation/gis.rst
+++ b/documentation/gis.rst
@@ -112,12 +112,13 @@ For example, the junctions GeoDataFrame contains the following information:
     :skipif: gpd is None
 
     >>> print(wn_gis.junctions.head())
-       node_type  elevation  initial_quality                   geometry
-    10  Junction    216.408        5.000e-04  POINT (20.00000 70.00000)
-    11  Junction    216.408        5.000e-04  POINT (30.00000 70.00000)
-    12  Junction    213.360        5.000e-04  POINT (50.00000 70.00000)
-    13  Junction    211.836        5.000e-04  POINT (70.00000 70.00000)
-    21  Junction    213.360        5.000e-04  POINT (30.00000 40.00000)
+         node_type  elevation  initial_quality                   geometry
+    name                                                                 
+    10    Junction    216.408        5.000e-04  POINT (20.00000 70.00000)
+    11    Junction    216.408        5.000e-04  POINT (30.00000 70.00000)
+    12    Junction    213.360        5.000e-04  POINT (50.00000 70.00000)
+    13    Junction    211.836        5.000e-04  POINT (70.00000 70.00000)
+    21    Junction    213.360        5.000e-04  POINT (30.00000 40.00000)
 
 Each GeoDataFrame contains attributes and geometry:
 

--- a/documentation/gis.rst
+++ b/documentation/gis.rst
@@ -114,12 +114,11 @@ For example, the junctions GeoDataFrame contains the following information:
     >>> print(wn_gis.junctions.head())
          node_type  elevation  initial_quality                   geometry
     name                                                                 
-    10    Junction    216.408           0.0005  POINT (20.00000 70.00000)
-    11    Junction    216.408           0.0005  POINT (30.00000 70.00000)
-    12    Junction    213.360           0.0005  POINT (50.00000 70.00000)
-    13    Junction    211.836           0.0005  POINT (70.00000 70.00000)
-    21    Junction    213.360           0.0005  POINT (30.00000 40.00000)
-
+    10    Junction    216.408        5.000e-04  POINT (20.00000 70.00000)
+    11    Junction    216.408        5.000e-04  POINT (30.00000 70.00000)
+    12    Junction    213.360        5.000e-04  POINT (50.00000 70.00000)
+    13    Junction    211.836        5.000e-04  POINT (70.00000 70.00000)
+    21    Junction    213.360        5.000e-04  POINT (30.00000 40.00000)
 Each GeoDataFrame contains attributes and geometry:
 
 Attributes

--- a/documentation/gis.rst
+++ b/documentation/gis.rst
@@ -114,11 +114,11 @@ For example, the junctions GeoDataFrame contains the following information:
     >>> print(wn_gis.junctions.head())
          node_type  elevation  initial_quality                   geometry
     name                                                                 
-    10    Junction    216.408        5.000e-04  POINT (20.00000 70.00000)
-    11    Junction    216.408        5.000e-04  POINT (30.00000 70.00000)
-    12    Junction    213.360        5.000e-04  POINT (50.00000 70.00000)
-    13    Junction    211.836        5.000e-04  POINT (70.00000 70.00000)
-    21    Junction    213.360        5.000e-04  POINT (30.00000 40.00000)
+    10    Junction    216.408           0.0005  POINT (20.00000 70.00000)
+    11    Junction    216.408           0.0005  POINT (30.00000 70.00000)
+    12    Junction    213.360           0.0005  POINT (50.00000 70.00000)
+    13    Junction    211.836           0.0005  POINT (70.00000 70.00000)
+    21    Junction    213.360           0.0005  POINT (30.00000 40.00000)
 
 Each GeoDataFrame contains attributes and geometry:
 
@@ -334,21 +334,23 @@ and then translates the GeoDataFrames coordinates to EPSG:3857.
 	
     >>> wn_gis = wntr.network.to_gis(wn, crs='EPSG:4326')
     >>> print(wn_gis.junctions.head())
-       node_type  elevation  initial_quality                   geometry
-    10  Junction    216.408        5.000e-04  POINT (20.00000 70.00000)
-    11  Junction    216.408        5.000e-04  POINT (30.00000 70.00000)
-    12  Junction    213.360        5.000e-04  POINT (50.00000 70.00000)
-    13  Junction    211.836        5.000e-04  POINT (70.00000 70.00000)
-    21  Junction    213.360        5.000e-04  POINT (30.00000 40.00000)
-	
+         node_type  elevation  initial_quality                   geometry
+    name                                                                 
+    10    Junction    216.408           0.0005  POINT (20.00000 70.00000)
+    11    Junction    216.408           0.0005  POINT (30.00000 70.00000)
+    12    Junction    213.360           0.0005  POINT (50.00000 70.00000)
+    13    Junction    211.836           0.0005  POINT (70.00000 70.00000)
+    21    Junction    213.360           0.0005  POINT (30.00000 40.00000)
+
     >>> wn_gis.to_crs('EPSG:3857')
     >>> print(wn_gis.junctions.head())
-       node_type  elevation  initial_quality                          geometry
-    10  Junction    216.408        5.000e-04  POINT (2226389.816 11068715.659)
-    11  Junction    216.408        5.000e-04  POINT (3339584.724 11068715.659)
-    12  Junction    213.360        5.000e-04  POINT (5565974.540 11068715.659)
-    13  Junction    211.836        5.000e-04  POINT (7792364.356 11068715.659)
-    21  Junction    213.360        5.000e-04   POINT (3339584.724 4865942.280)
+         node_type  elevation  initial_quality                          geometry
+    name                                                                        
+    10    Junction    216.408           0.0005  POINT (2226389.816 11068715.659)
+    11    Junction    216.408           0.0005  POINT (3339584.724 11068715.659)
+    12    Junction    213.360           0.0005  POINT (5565974.540 11068715.659)
+    13    Junction    211.836           0.0005  POINT (7792364.356 11068715.659)
+    21    Junction    213.360           0.0005   POINT (3339584.724 4865942.280)
 
 Snap point geometries to the nearest point or line
 ----------------------------------------------------

--- a/wntr/gis/geospatial.py
+++ b/wntr/gis/geospatial.py
@@ -64,8 +64,7 @@ def snap(A, B, tolerance):
     assert A.crs == B.crs
     
     # Modify B to include "indexB" as a separate column
-    B = B.reset_index()
-    B.rename(columns={'index':'indexB'}, inplace=True)
+    B = B.reset_index(names='indexB')
     
     # Define the coordinate reference system, based on B
     crs = B.crs

--- a/wntr/gis/geospatial.py
+++ b/wntr/gis/geospatial.py
@@ -227,7 +227,7 @@ def intersect(A, B, B_value=None, include_background=False, background_value=0):
     
     n = intersects.groupby('_tmp_index_name')['geometry'].count()
     B_indices = intersects.groupby('_tmp_index_name')['index_right'].apply(list)
-    stats = pd.DataFrame(index=A.index, data={'intersections': B_indices,
+    stats = pd.DataFrame(index=A.index.copy(), data={'intersections': B_indices,
                                               'n': n,})
     stats['n'] = stats['n'].fillna(0)
     stats['n'] = stats['n'].apply(int)

--- a/wntr/gis/network.py
+++ b/wntr/gis/network.py
@@ -133,7 +133,6 @@ class WaterNetworkGIS:
                 # Set index
                 if len(df) > 0:
                     df.set_index('name', inplace=True)
-                    df.index.name = None
                 
                 df = gpd.GeoDataFrame(df, crs=crs, geometry=geom)
             else:
@@ -321,7 +320,7 @@ class WaterNetworkGIS:
             data = gpd.read_file(files['valves']).set_index(index_col)
             self.valves = pd.concat([self.valves, data])
 
-    def read_geojson(self, files, index_col='index'):
+    def read_geojson(self, files, index_col='name'):
         """
         Append information from GeoJSON files to a WaterNetworkGIS object
 
@@ -336,7 +335,7 @@ class WaterNetworkGIS:
         """
         self._read(files, index_col)
 
-    def read_shapefile(self, files, index_col='index'):
+    def read_shapefile(self, files, index_col='name'):
         """
         Append information from Esri Shapefiles to a WaterNetworkGIS object
 

--- a/wntr/gis/network.py
+++ b/wntr/gis/network.py
@@ -299,7 +299,7 @@ class WaterNetworkGIS:
                     self.pumps[name] = np.nan
                 self.pumps.loc[link_name, name] = value
     
-    def _read(self, files, index_col='index'):
+    def _read(self, files, index_col='name'):
         
         if 'junctions' in files.keys():
             data = gpd.read_file(files['junctions']).set_index(index_col)

--- a/wntr/network/io.py
+++ b/wntr/network/io.py
@@ -551,7 +551,7 @@ def write_geojson(wn, prefix: str, crs=None, pumps_as_points=True,
     wn_gis.write_geojson(prefix=prefix)
 
 
-def read_geojson(files, index_col='index', append=None):
+def read_geojson(files, index_col='name', append=None):
     """
     Create or append a WaterNetworkModel from GeoJSON files
 
@@ -612,7 +612,7 @@ def write_shapefile(wn, prefix: str, crs=None, pumps_as_points=True,
                        valves_as_points=valves_as_points)
     wn_gis.write_shapefile(prefix=prefix)
 
-def read_shapefile(files, index_col='index', append=None):
+def read_shapefile(files, index_col='name', append=None):
     """
 
     Create or append a WaterNetworkModel from Esri Shapefiles
@@ -635,7 +635,7 @@ def read_shapefile(files, index_col='index', append=None):
 
     """
     gis_data = WaterNetworkGIS()
-    gis_data.read_shapefile(files, index_col='index')
+    gis_data.read_shapefile(files,index_col=index_col)
     wn = gis_data._create_wn(append=append)
 
     return wn


### PR DESCRIPTION
## Summary
Changes default name column from 'index' to 'name' and removes a couple of instances where it was assumed that there was a column 'index'.

Fixes #433 

## Tests and documentation
n/a - not a new feature
 
## Acknowledgement
By contributing to this software project, I acknowledge that I have reviewed the [software quality assurance guidelines](https://wntr.readthedocs.io/en/stable/developers.html) and that my contributions are submitted under the [Revised BSD License](https://wntr.readthedocs.io/en/stable/license.html). 
