### PR TITLE
add max version for fiona

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -37,7 +37,7 @@ jobs:
         python setup.py bdist_wheel
         ls dist/*
     - name: Save wheel
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4.4.0
       with:
         name: wntr_${{ matrix.python-version }}_${{ matrix.os }}.whl
         path: dist/wntr*
@@ -96,7 +96,7 @@ jobs:
         COVERAGE_FILE: .coverage.${{ matrix.python-version }}.${{ matrix.os }}
         
     - name: Save coverage
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4.4.0
       with:
         name: coverage
         path: .coverage.${{ matrix.python-version }}.${{ matrix.os }}
@@ -136,12 +136,12 @@ jobs:
         coverage json --pretty-print
         coverage html --show-contexts
     - name: Save coverage JSON
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4.4.0
       with:
         name: coverage
         path: coverage.json
     - name: Save coverage html
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4.4.0
       with:
         name: coverage
         path: htmlcov

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -37,7 +37,7 @@ jobs:
         python setup.py bdist_wheel
         ls dist/*
     - name: Save wheel
-      uses: actions/upload-artifact@v4.4.0
+      uses: actions/upload-artifact@v4
       with:
         name: wntr_${{ matrix.python-version }}_${{ matrix.os }}.whl
         path: dist/wntr*
@@ -56,7 +56,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Download wheel
-      uses: actions/download-artifact@v4.1.7
+      uses: actions/download-artifact@v4
       with:
         name: wntr_${{ matrix.python-version }}_${{ matrix.os }}.whl
     - name: Install wntr
@@ -96,7 +96,7 @@ jobs:
         COVERAGE_FILE: .coverage.${{ matrix.python-version }}.${{ matrix.os }}
         
     - name: Save coverage
-      uses: actions/upload-artifact@v4.4.0
+      uses: actions/upload-artifact@v4
       with:
         name: coverage
         path: .coverage.${{ matrix.python-version }}.${{ matrix.os }}
@@ -117,7 +117,7 @@ jobs:
         python -m pip install -e .
     # pip install coveralls
     - name: Download coverage artifacts from test matrix
-      uses: actions/download-artifact@v4.1.7
+      uses: actions/download-artifact@v4
       with:
         name: coverage
     - name: Setup coverage and combine reports
@@ -136,12 +136,12 @@ jobs:
         coverage json --pretty-print
         coverage html --show-contexts
     - name: Save coverage JSON
-      uses: actions/upload-artifact@v4.4.0
+      uses: actions/upload-artifact@v4
       with:
         name: coverage
         path: coverage.json
     - name: Save coverage html
-      uses: actions/upload-artifact@v4.4.0
+      uses: actions/upload-artifact@v4
       with:
         name: coverage
         path: htmlcov
@@ -163,7 +163,7 @@ jobs:
         pip install -r requirements.txt
         python -m pip install -e .
     - name: Download coverage artifacts from test matrix
-      uses: actions/download-artifact@v4.1.7
+      uses: actions/download-artifact@v4
       with:
         name: coverage
     - name: Setup coverage and combine reports

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -56,7 +56,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Download wheel
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4.1.7
       with:
         name: wntr_${{ matrix.python-version }}_${{ matrix.os }}.whl
     - name: Install wntr
@@ -117,7 +117,7 @@ jobs:
         python -m pip install -e .
     # pip install coveralls
     - name: Download coverage artifacts from test matrix
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4.1.7
       with:
         name: coverage
     - name: Setup coverage and combine reports
@@ -163,7 +163,7 @@ jobs:
         pip install -r requirements.txt
         python -m pip install -e .
     - name: Download coverage artifacts from test matrix
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4.1.7
       with:
         name: coverage
     - name: Setup coverage and combine reports

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ folium
 utm
 openpyxl
 geopandas<1.0
+fiona<1.10
 rtree
 
 # Documentation


### PR DESCRIPTION
## Summary
geopandas uses apparently deprecated fiona call which causes breakage, requiring fiona below 1.10 prevents this.

Provide a summary of the proposed changes, describe tests and documentation, and review the acknowledgement below. 
 

## Tests and documentation
n/a
 
## Acknowledgement
By contributing to this software project, I acknowledge that I have reviewed the [software quality assurance guidelines](https://wntr.readthedocs.io/en/stable/developers.html) and that my contributions are submitted under the [Revised BSD License](https://wntr.readthedocs.io/en/stable/license.html). 
