### PR TITLE
Bug fix in roughness unit conversion when using D-W

### DIFF
--- a/wntr/epanet/io.py
+++ b/wntr/epanet/io.py
@@ -674,6 +674,8 @@ class InpFile(object):
         f.write('\n'.encode(sys_default_enc))
 
     def _read_pipes(self):
+        darcy_weisbach = self.wn.options.hydraulic.headloss == "D-W"
+        
         for lnum, line in self.sections['[PIPES]']:
             line = line.split(';')[0]
             current = line.split()
@@ -701,7 +703,8 @@ class InpFile(object):
                         current[2],
                         to_si(self.flow_units, float(current[3]), HydParam.Length),
                         to_si(self.flow_units, float(current[4]), HydParam.PipeDiameter),
-                        float(current[5]),
+                        to_si(self.flow_units, float(current[5]), HydParam.RoughnessCoeff, 
+                              darcy_weisbach=darcy_weisbach),
                         minor_loss,
                         link_status,
                         check_valve)
@@ -711,6 +714,8 @@ class InpFile(object):
                 raise ENValueError(211, str(e.args[0]), line_num=lnum) from e
 
     def _write_pipes(self, f, wn):
+        darcy_weisbach = wn.options.hydraulic.headloss == "D-W"
+        
         f.write('[PIPES]\n'.encode(sys_default_enc))
         f.write(_PIPE_LABEL.format(';ID', 'Node1', 'Node2', 'Length', 'Diameter',
                                    'Roughness', 'Minor Loss', 'Status').encode(sys_default_enc))
@@ -723,7 +728,9 @@ class InpFile(object):
                  'node2': pipe.end_node_name,
                  'len': from_si(self.flow_units, pipe.length, HydParam.Length),
                  'diam': from_si(self.flow_units, pipe.diameter, HydParam.PipeDiameter),
-                 'rough': pipe.roughness,
+                 'rough': from_si(self.flow_units, pipe.roughness, 
+                                  HydParam.RoughnessCoeff, 
+                                  darcy_weisbach=darcy_weisbach),
                  'mloss': pipe.minor_loss,
                  'status': str(pipe.initial_status),
                  'com': ';'}

--- a/wntr/epanet/util.py
+++ b/wntr/epanet/util.py
@@ -571,7 +571,7 @@ class HydParam(enum.Enum):
 
         elif self in [HydParam.RoughnessCoeff] and darcy_weisbach:
             if flow_units.is_traditional:
-                data = data * (1000.0 * 0.3048)  # 1e-3 ft to m
+                data = data * (0.001 * 0.3048)  # 1e-3 ft to m
             elif flow_units.is_metric:
                 data = data * 0.001  # mm to m
 
@@ -668,7 +668,7 @@ class HydParam(enum.Enum):
 
         elif self in [HydParam.RoughnessCoeff] and darcy_weisbach:
             if flow_units.is_traditional:
-                data = data / (1000.0 * 0.3048)  # 1e-3 ft from m
+                data = data / (0.001 * 0.3048)  # 1e-3 ft from m
             elif flow_units.is_metric:
                 data = data / 0.001  # mm from m
 

--- a/wntr/network/options.py
+++ b/wntr/network/options.py
@@ -10,6 +10,7 @@ The wntr.network.options module includes simulation options.
 """
 import re
 import logging
+import warnings
 import copy
 
 logger = logging.getLogger(__name__)
@@ -406,6 +407,19 @@ class HydraulicOptions(_OptionsBase):
             value = str.upper(value)
             if value not in ['H-W', 'D-W', 'C-M']:
                 raise ValueError('headloss must be one of "H-W", "D-W", or "C-M"')
+            # If headloss is changed from ['H-W', 'C-M'] to/from 'D-W', print
+            # a warning, the units of the roughness coefficient cannot be 
+            # converted from unitless to length (0.001 ft or mm)
+            try:
+                orig_value = self.__dict__[name]
+            except:
+                orig_value = None
+            if orig_value is not None:
+                if (orig_value in ['H-W', 'C-M'] and value == 'D-W') or \
+                   (value in ['H-W', 'C-M'] and orig_value == 'D-W'):
+                   warnings.warn('Changing the headloss formula from ' +
+                                 orig_value + ' to ' + value +
+                                 ' will not change the units of the roughness coefficient.')
         elif name == 'hydraulics':
             if value is not None:
                 value = str.upper(value)

--- a/wntr/tests/test_epanet_io.py
+++ b/wntr/tests/test_epanet_io.py
@@ -701,11 +701,11 @@ class TestNet3InpUnitsResults(unittest.TestCase):
                 temp = results.node['pressure'].loc[0,wn.junction_name_list]
                 pressure[headloss+', '+units] = temp
         
-        import matplotlib.pylab as plt
-        import pandas as pd
-        plt.figure()
-        pd.DataFrame(pressure).plot.bar()
-        plt.legend() #loc='lower right')
+        #import matplotlib.pylab as plt
+        #import pandas as pd
+        #plt.figure()
+        #pd.DataFrame(pressure).plot.bar()
+        #plt.legend() #loc='lower right')
         
         ## Compares all results to H-W, GPM
         threshold = 0.55


### PR DESCRIPTION
## Summary
The following PR addresses #443 regarding unit conversion of the roughness coefficient when using D-W headloss formula.  This update only impacts the EpanetSimulator which requires the unit conversion when reading/writing the INP file. The WNTRSimulator does not support D-W headloss formula.  

The original code did not convert roughness in `_read_pipes` and `_write_pipes`. The `to_si` and `from_si` conversion functions for roughness were also incorrect and updated.

If `wn.options.hydraulic.headloss` is changed from ['H-W', 'C-M'] to/from 'D-W', a UserWarning is printed to the screen.  The units of headloss cannot be converted from unitless to/from length.

## Tests and documentation
Tests were added to `test_epanet_io.py`.  The mean absolute error in pressure values for Net3 is within 0.55 m when using H-W, C-M, and D-W with GPM and LPS.
 
## Acknowledgement
By contributing to this software project, I acknowledge that I have reviewed the [software quality assurance guidelines](https://wntr.readthedocs.io/en/stable/developers.html) and that my contributions are submitted under the [Revised BSD License](https://wntr.readthedocs.io/en/stable/license.html). 
