### PR TITLE
Update workflows to test documentation

### DIFF
--- a/.github/workflows/build_deploy_pages.yml
+++ b/.github/workflows/build_deploy_pages.yml
@@ -1,11 +1,12 @@
-# This is a basic workflow to help you get started with Actions
-
 name: docs
 
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
   workflow_dispatch:
+
 jobs:
   build:
     name: Build the documentation with Sphinx
@@ -36,6 +37,7 @@ jobs:
   deploy:
     name: Deploy documentation to GitHub Pages
     needs: build
+    if: github.event_name == 'push'
     permissions:
       contents: read
       pages: write      # to deploy to Pages

--- a/.github/workflows/quick_check.yml
+++ b/.github/workflows/quick_check.yml
@@ -33,7 +33,8 @@ jobs:
         python -m pip install -e .
     - name: Run tests and coverage (unittests plus doctests)
       run: |
-        coverage run --source=wntr --omit="*/tests/*","*/sim/network_isolation/network_isolation.py","*/sim/aml/evaluator.py" -m pytest -m "not time_consuming" --doctest-modules --doctest-glob="*.rst" wntr        
+        coverage run --source=wntr --omit="*/tests/*","*/sim/network_isolation/network_isolation.py","*/sim/aml/evaluator.py" -m pytest -m "not time_consuming" --doctest-modules --doctest-glob="*.rst" wntr
+        coverage run --source=wntr --omit="*/tests/*","*/sim/network_isolation/network_isolation.py","*/sim/aml/evaluator.py" --append -m pytest --doctest-glob="*.rst" documentation        
         coverage report --fail-under=70        
     # coverage run --source=wntr --omit="*/tests/*" --append -m pytest --doctest-glob="*.rst" documentation 
 


### PR DESCRIPTION
 ## Summary
This PR updates the `quick_check` and  `build_deploy_pages` workflows to test documentation.
- `quick_check` now runs the doctests in addition to the main testing suite.
- `build_deploy_pages` now builds the documentation on pull requests instead of just pushes. This allows us to see if a PR will break the documentation or not before pulling it in. The deploy part of the workflow will only trigger for pushes. 
## Tests and documentation
N/A
## Acknowledgement
By contributing to this software project, I acknowledge that I have reviewed the [software quality assurance guidelines](https://wntr.readthedocs.io/en/stable/developers.html) and that my contributions are submitted under the [Revised BSD License](https://wntr.readthedocs.io/en/stable/license.html). 
