### PR TITLE
Fix Pumps efficiency type on documentation

### DIFF
--- a/wntr/network/elements.py
+++ b/wntr/network/elements.py
@@ -1099,7 +1099,7 @@ class Pump(Link):
 
     @property
     def efficiency(self): 
-        """float : pump efficiency"""
+        """Curve : pump efficiency"""
         return self._efficiency
     @efficiency.setter
     def efficiency(self, value):


### PR DESCRIPTION
A simple fix on the Pumps efficiency type described on the documentation.
 
## Summary
It was stated as a float, but it's actually a Curve.

## Tests and documentation
I don't think it requires any tests.
 
## Acknowledgement
By contributing to this software project, I acknowledge that I have reviewed the [software quality assurance guidelines](https://wntr.readthedocs.io/en/stable/developers.html) and that my contributions are submitted under the [Revised BSD License](https://wntr.readthedocs.io/en/stable/license.html). 
