### PR TITLE
Fix building and testing issues

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -35,8 +35,8 @@ jobs:
     - name: Conditionally set env var
       if: runner.os == 'macOS' && matrix.os == 'macos-13'
       run: |
-        echo "Setting MACOSX_DEPLOYMENT_TARGET to 13.0"
-        echo "MACOSX_DEPLOYMENT_TARGET=13.0" >> $GITHUB_ENV
+        echo "Setting MACOSX_DEPLOYMENT_TARGET to 14.0"
+        echo "MACOSX_DEPLOYMENT_TARGET=14.0" >> $GITHUB_ENV
 
     - name: Build wheel
       run: |

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -87,8 +87,12 @@ jobs:
           requirements.txt
           wntr/tests/
           examples/
+          wntr/epanet/libepanet/darwin-formula/libomp.rb
         sparse-checkout-cone-mode: false
         fetch-depth: 1
+    - if: ${{ matrix.os == 'macos-latest' || matrix.os == 'macOS-13'}}
+      run: |
+        brew reinstall --build-from-source --formula wntr/epanet/libepanet/darwin-formula/libomp.rb
     - name: Test wntr
       run: |
         pip install -r requirements.txt

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Test wntr
       run: |
         pip install -r requirements.txt
-        pytest --pyargs wntr.tests.test_sim_results
+        pytest --rootdir=$(python -c "import wntr; print(wntr.__path__[0] + '/tests')") --pyargs wntr.tests.test_sim_results
   pytest_coverage:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -40,18 +40,15 @@ jobs:
         pip install wheel
         pip install -r requirements.txt
 
-    - name: Build wheel (macOS-13 specific plat-name override)
+        
+    - name: Build macos-13
+      if: ${{ matrix.os == 'macOS-13'}}
       run: |
-        if [[ "$RUNNER_OS" == "macOS-13"]]; then
-          python setup.py bdist_wheel --plat-name macosx-13.0-universal2 --verbose
-        else
-          python setup.py bdist_wheel --verbose
-        fi
+        python setup.py bdist_wheel --plat-name macosx-13.0-universal2 --verbose
         ls dist/*
-
-    - name: Build wheel
+    - name: Build all other OS
+      if: ${{ matrix.os != 'macOS-13'}}
       run: |
-        # Hammer to use if all else fails for macos-13 case: python setup.py bdist_wheel --plat-name macosx-13.0-universal2
         python setup.py bdist_wheel --verbose
         ls dist/*
     - name: Save wheel

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -37,13 +37,14 @@ jobs:
         python3 -c "import platform; print(platform.mac_ver())"
         python3 -c "import sysconfig; print(sysconfig.get_platform())"
         python3 -c "from distutils.util import get_platform; print(get_platform())"
+
+    - name: Macos debug
+      if: runner.os == 'macOS'
+      run: |
+        xcodebuild -version
         echo $MACOSX_DEPLOYMENT_TARGET
         export MACOSX_DEPLOYMENT_TARGET=13.0
         echo $MACOSX_DEPLOYMENT_TARGET
-
-    - name: Run xcodebuild version (macos only)
-      if: runner.os == 'macOS'
-      run: xcodebuild -version
 
     - name: Build wheel
       run: |

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -40,8 +40,6 @@ jobs:
 
     - name: Build wheel
       run: |
-        if [[ "${{ matrix.os }}" == "macos-13" ]]; then
-          export MACOSX_DEPLOYMENT_TARGET="13.0"
         python setup.py bdist_wheel
         ls dist/*
     - name: Save wheel

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -96,7 +96,7 @@ jobs:
     - name: Test wntr
       run: |
         pip install -r requirements.txt
-        pytest wntr/tests/ 
+        pytest wntr/tests/ --ignore=wntr/tests/test_demos.py
   pytest_coverage:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -34,6 +34,8 @@ jobs:
         pip install -r requirements.txt
     - name: Build wheel
       run: |
+        if [[ "${{ matrix.os }}" == "macos-13" ]]; then
+          export MACOSX_DEPLOYMENT_TARGET="13.0"
         python setup.py bdist_wheel
         ls dist/*
     - name: Save wheel

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -80,13 +80,6 @@ jobs:
     - name: Import wntr
       run: |
         python -c "import wntr"
-    - name: Checkout requirements.txt
-      uses: actions/checkout@v4
-    - name: Test wntr
-      run: |
-        pip install -r requirements.txt
-        python -c "import wntr; print(wntr.__file__)"
-        pytest wntr/tests/
   pytest_coverage:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -85,12 +85,14 @@ jobs:
       with:
         sparse-checkout: |
           requirements.txt
+          wntr/tests/
+          examples/
         sparse-checkout-cone-mode: false
         fetch-depth: 1
     - name: Test wntr
       run: |
         pip install -r requirements.txt
-        pytest --rootdir=$(python -c "import wntr; print(wntr.__path__[0] + '/tests')") --pyargs wntr.tests.test_sim_results
+        pytest wntr/tests/ 
   pytest_coverage:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
     steps:
     - name: Macos debug
-      if: runner.os == 'macOS'
+      if: runner.os == 'macOS-13'
       run: |
         xcodebuild -version
         echo $MACOSX_DEPLOYMENT_TARGET

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -80,6 +80,13 @@ jobs:
     - name: Import wntr
       run: |
         python -c "import wntr"
+    - name: Checkout requirements.txt
+      uses: actions/checkout@v4
+    - name: Test wntr
+      run: |
+        pip install -r requirements.txt
+        python -c "import wntr; print(wntr.__file__)"
+        coverage run --context=${{ matrix.os }}.py${{ matrix.python-version }} --source=wntr --omit="*/tests/*","*/sim/network_isolation/network_isolation.py","*/sim/aml/evaluator.py" -m pytest  --doctest-modules --doctest-glob="*.rst" wntr
   pytest_coverage:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -40,7 +40,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: wntr_${{ matrix.python-version }}_${{ matrix.os }}.whl
-        path: dist/wntr*
+        path: dist/wntr_${{ matrix.python-version }}_${{ matrix.os }}.whl
 
   install_import:
     needs: build

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -21,11 +21,6 @@ jobs:
         os: [windows-latest, macOS-13, macos-latest, ubuntu-latest]
       fail-fast: false
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
     - name: Macos debug
       if: runner.os == 'macOS'
       run: |
@@ -33,6 +28,11 @@ jobs:
         echo $MACOSX_DEPLOYMENT_TARGET
         export MACOSX_DEPLOYMENT_TARGET=13.0
         echo $MACOSX_DEPLOYMENT_TARGET
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         python --version

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -32,6 +32,12 @@ jobs:
         python -m pip install --upgrade pip
         pip install wheel
         pip install -r requirements.txt
+    - name: Conditionally set env var
+      if: runner.os == 'macOS' && matrix.os == 'macos-13'
+      run: |
+        echo "Setting MACOSX_DEPLOYMENT_TARGET to 13.0"
+        echo "MACOSX_DEPLOYMENT_TARGET=13.0" >> $GITHUB_ENV
+
     - name: Build wheel
       run: |
         if [[ "${{ matrix.os }}" == "macos-13" ]]; then

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -85,11 +85,13 @@ jobs:
       with:
         sparse-checkout: |
           requirements.txt
+          wntr/tests/
+        sparse-checkout-cone-mode: false
         fetch-depth: 1
     - name: Test wntr
       run: |
         pip install -r requirements.txt
-        pytest --pyargs wntr.tests.test_sim_results
+        coverage run --context=${{ matrix.os }}.py${{ matrix.python-version }} --source=wntr --omit="*/tests/*","*/sim/network_isolation/network_isolation.py","*/sim/aml/evaluator.py" -m pytest  --doctest-modules --doctest-glob="*.rst" wntr
   pytest_coverage:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -96,7 +96,7 @@ jobs:
     - name: Test wntr
       run: |
         pip install -r requirements.txt
-        pytest wntr/tests/ --ignore=wntr/tests/test_demos.py
+        pytest wntr/tests/ --ignore=wntr/tests/test_demos.py --ignore=wntr/tests/test_examples.py
   pytest_coverage:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -40,7 +40,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: wntr_${{ matrix.python-version }}_${{ matrix.os }}.whl
-        path: dist/wntr_${{ matrix.python-version }}_${{ matrix.os }}.whl
+        path: dist/wntr*
 
   install_import:
     needs: build

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -26,18 +26,6 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python --version
-        python -m pip install --upgrade pip
-        pip install wheel
-        pip install -r requirements.txt
-    - name: Debugging
-      run: |
-        python3 -c "import platform; print(platform.mac_ver())"
-        python3 -c "import sysconfig; print(sysconfig.get_platform())"
-        python3 -c "from distutils.util import get_platform; print(get_platform())"
-
     - name: Macos debug
       if: runner.os == 'macOS'
       run: |
@@ -45,6 +33,12 @@ jobs:
         echo $MACOSX_DEPLOYMENT_TARGET
         export MACOSX_DEPLOYMENT_TARGET=13.0
         echo $MACOSX_DEPLOYMENT_TARGET
+    - name: Install dependencies
+      run: |
+        python --version
+        python -m pip install --upgrade pip
+        pip install wheel
+        pip install -r requirements.txt
 
     - name: Build wheel
       run: |

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -89,7 +89,7 @@ jobs:
     - name: Test wntr
       run: |
         pip install -r requirements.txt
-        pytest --pyargs wntr.tests
+        pytest --pyargs wntr.tests.test_sim_results
   pytest_coverage:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -77,12 +77,19 @@ jobs:
         python -m pip install --upgrade pip
         pip install wheel "numpy>=1.2.1,<2.0" scipy networkx pandas matplotlib setuptools
         pip install --no-index --pre --find-links=. wntr
-        pip install pytest
-    - name: Usage of wntr
+    - name: Import wntr
       run: |
         python -c "import wntr"
+    - name: Checkout requirements.txt
+      uses: actions/checkout@v4
+      with:
+        sparse-checkout: |
+          requirements.txt
+        fetch-depth: 1
+    - name: Test wntr
+      run: |
+        pip install -r requirements.txt
         pytest --pyargs wntr.tests
-
   pytest_coverage:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -86,7 +86,7 @@ jobs:
       run: |
         pip install -r requirements.txt
         python -c "import wntr; print(wntr.__file__)"
-        coverage run --context=${{ matrix.os }}.py${{ matrix.python-version }} --source=wntr --omit="*/tests/*","*/sim/network_isolation/network_isolation.py","*/sim/aml/evaluator.py" -m pytest  --doctest-modules --doctest-glob="*.rst" wntr
+        pytest wntr/tests/
   pytest_coverage:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -38,11 +38,14 @@ jobs:
         python3 -c "import sysconfig; print(sysconfig.get_platform())"
         python3 -c "from distutils.util import get_platform; print(get_platform())"
         echo $MACOSX_DEPLOYMENT_TARGET
+        export MACOSX_DEPLOYMENT_TARGET=13.0
+        echo $MACOSX_DEPLOYMENT_TARGET
+        xcodebuild -version
 
     - name: Build wheel
       run: |
         # Hammer to use if all else fails for macos-13 case: python setup.py bdist_wheel --plat-name macosx-13.0-universal2
-        python setup.py bdist_wheel 
+        python setup.py bdist_wheel --verbose
         ls dist/*
     - name: Save wheel
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -40,7 +40,10 @@ jobs:
         echo $MACOSX_DEPLOYMENT_TARGET
         export MACOSX_DEPLOYMENT_TARGET=13.0
         echo $MACOSX_DEPLOYMENT_TARGET
-        xcodebuild -version
+
+    - name: Run xcodebuild version (macos only)
+      if: runner.os == 'macOS'
+      run: xcodebuild -version
 
     - name: Build wheel
       run: |

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -80,18 +80,6 @@ jobs:
     - name: Import wntr
       run: |
         python -c "import wntr"
-    - name: Checkout requirements.txt
-      uses: actions/checkout@v4
-      with:
-        sparse-checkout: |
-          requirements.txt
-          wntr/tests/
-        sparse-checkout-cone-mode: false
-        fetch-depth: 1
-    - name: Test wntr
-      run: |
-        pip install -r requirements.txt
-        coverage run --context=${{ matrix.os }}.py${{ matrix.python-version }} --source=wntr --omit="*/tests/*","*/sim/network_isolation/network_isolation.py","*/sim/aml/evaluator.py" -m pytest  --doctest-modules --doctest-glob="*.rst" wntr
   pytest_coverage:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -21,8 +21,8 @@ jobs:
         os: [windows-latest, macOS-13, macos-latest, ubuntu-latest]
       fail-fast: false
     steps:
-    - name: Macos debug
-      if: runner.os == 'macOS-13'
+    - name: Macos debug and set deployment target variable
+      if: ${{ matrix.os == 'macOS-13'}}
       run: |
         xcodebuild -version
         echo $MACOSX_DEPLOYMENT_TARGET
@@ -38,10 +38,8 @@ jobs:
         python --version
         python -m pip install --upgrade pip
         pip install wheel
-        pip install -r requirements.txt
-
-        
-    - name: Build macos-13
+        pip install -r requirements.txt  
+    - name: Build macOS-13 # Special case due to unresolved wheel naming bug.
       if: ${{ matrix.os == 'macOS-13'}}
       run: |
         python setup.py bdist_wheel --plat-name macosx-13.0-universal2 --verbose
@@ -79,9 +77,11 @@ jobs:
         python -m pip install --upgrade pip
         pip install wheel "numpy>=1.2.1,<2.0" scipy networkx pandas matplotlib setuptools
         pip install --no-index --pre --find-links=. wntr
+        pip install pytest
     - name: Usage of wntr
       run: |
         python -c "import wntr"
+        pytest --pyargs wntr.tests
 
   pytest_coverage:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -32,15 +32,17 @@ jobs:
         python -m pip install --upgrade pip
         pip install wheel
         pip install -r requirements.txt
-    - name: Conditionally set env var
-      if: runner.os == 'macOS' && matrix.os == 'macos-13'
+    - name: Debugging
       run: |
-        echo "Setting MACOSX_DEPLOYMENT_TARGET to 14.0"
-        echo "MACOSX_DEPLOYMENT_TARGET=14.0" >> $GITHUB_ENV
+        python3 -c "import platform; print(platform.mac_ver())"
+        python3 -c "import sysconfig; print(sysconfig.get_platform())"
+        python3 -c "from distutils.util import get_platform; print(get_platform())"
+        echo $MACOSX_DEPLOYMENT_TARGET
 
     - name: Build wheel
       run: |
-        python setup.py bdist_wheel
+        # Hammer to use if all else fails for macos-13 case: python setup.py bdist_wheel --plat-name macosx-13.0-universal2
+        python setup.py bdist_wheel 
         ls dist/*
     - name: Save wheel
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -80,6 +80,17 @@ jobs:
     - name: Import wntr
       run: |
         python -c "import wntr"
+    - name: Checkout requirements.txt
+      uses: actions/checkout@v4
+      with:
+        sparse-checkout: |
+          requirements.txt
+        sparse-checkout-cone-mode: false
+        fetch-depth: 1
+    - name: Test wntr
+      run: |
+        pip install -r requirements.txt
+        pytest --pyargs wntr.tests.test_sim_results
   pytest_coverage:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -40,6 +40,15 @@ jobs:
         pip install wheel
         pip install -r requirements.txt
 
+    - name: Build wheel (macOS-13 specific plat-name override)
+      run: |
+        if [[ "$RUNNER_OS" == "macOS-13"]]; then
+          python setup.py bdist_wheel --plat-name macosx-13.0-universal2 --verbose
+        else
+          python setup.py bdist_wheel --verbose
+        fi
+        ls dist/*
+
     - name: Build wheel
       run: |
         # Hammer to use if all else fails for macos-13 case: python setup.py bdist_wheel --plat-name macosx-13.0-universal2

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,10 @@
 include README.md
 include LICENSE.md
-include wntr/epanet/libepanet/*
+include wntr/epanet/libepanet/darwin-arm/*
+include wntr/epanet/libepanet/darwin-formula/*
+include wntr/epanet/libepanet/darwin-x64/*
+include wntr/epanet/libepanet/linux-x64/*
+include wntr/epanet/libepanet/windows-x64/*
 include wntr/sim/aml/evaluator*
 include wntr/sim/aml/numpy.i
 include wntr/sim/network_isolation/network_isolation*

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,3 +12,8 @@ include wntr/sim/network_isolation/numpy.i
 include wntr/tests/networks_for_testing/*.inp
 include wntr/library/msx/*.json
 include wntr/library/msx/*.msx
+include wntr/tests/networks_for_testing/*
+include wntr/tests/data_for_testing/*
+include examples/*
+include examples/demos/*
+include examples/networks/*

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,8 +12,3 @@ include wntr/sim/network_isolation/numpy.i
 include wntr/tests/networks_for_testing/*.inp
 include wntr/library/msx/*.json
 include wntr/library/msx/*.msx
-include wntr/tests/networks_for_testing/*
-include wntr/tests/data_for_testing/*
-include examples/*
-include examples/demos/*
-include examples/networks/*

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,8 +1,6 @@
 include README.md
 include LICENSE.md
-include wntr/epanet/Darwin/*
-include wntr/epanet/Linux/*
-include wntr/epanet/Windows/*
+include wntr/epanet/libepanet/*
 include wntr/sim/aml/evaluator*
 include wntr/sim/aml/numpy.i
 include wntr/sim/network_isolation/network_isolation*
@@ -10,4 +8,3 @@ include wntr/sim/network_isolation/numpy.i
 include wntr/tests/networks_for_testing/*.inp
 include wntr/library/msx/*.json
 include wntr/library/msx/*.msx
-include wntr/epanet/libepanet/darwin-formula/libomp.rb

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ matplotlib
 setuptools
 
 # Optional
-plotly
+plotly<6.0
 folium
 utm
 openpyxl


### PR DESCRIPTION
## Summary
This PR addresses several issues with the building and testing process for WNTR:
- wntr 1.3.0 wheels do not include the epanet binaries. This is the cause of #466.
    - This is addressed by correctly referencing the binaries in MANIFEST.in.
- during the install_import step of the build job, only a basic `import wntr` test is run on the installed wheel. This causes us to miss deeper problems with the wheel such as the missing binaries mentioned above.
    - This is addressed by testing the wntr test suite after installing the wheels.
- The wheel for macos-13 is saved with the wrong name (references macos version 14.0 instead of 13.0) and cannot be found when installing from wheels on that OS.
    - This is addressed by forcing the MACOSX_DEPLOYMENT_TARGET environment variable to "13.0" when building for macos-13, which ensures the correct version of macos is targetted. However, the naming issue persists even with this update so the platform name is forced when running the build command.
- Plotly introduced breaking changes in the latest major version (6.0.0) which affect plot_interactive_network and causes tests to fail. I believe this is the relevant change: plotly/plotly.js/pull/7212.
    
    - This is addressed by placing an upper bound in requirements.txt to avoid installing the latest version. Future updates, either in this PR or a separate one, can address the breaking change so that the upper bound is unnecessary.

## Tests and documentation
n/a
 
## Acknowledgement
By contributing to this software project, I acknowledge that I have reviewed the [software quality assurance guidelines](https://wntr.readthedocs.io/en/stable/developers.html) and that my contributions are submitted under the [Revised BSD License](https://wntr.readthedocs.io/en/stable/license.html). 
