### PR TITLE
Check valve fix

### DIFF
--- a/wntr/network/elements.py
+++ b/wntr/network/elements.py
@@ -857,7 +857,7 @@ class Pipe(Link):
         roughness
         minor_loss
         initial_status
-        cv
+        check_valve
         bulk_coeff
         wall_coeff
         vertices
@@ -900,7 +900,7 @@ class Pipe(Link):
         self._diameter = 0.3048
         self._roughness = 100
         self._minor_loss = 0.0
-        self._cv = False
+        self._check_valve = False
         self._bulk_coeff = None
         self._wall_coeff = None
         self._velocity = None
@@ -963,13 +963,22 @@ class Pipe(Link):
         self._minor_loss = value
 
     @property
-    def cv(self):
+    def check_valve(self):
         """bool : does this pipe have a check valve"""
-        return self._cv
+        return self._check_valve
+    @check_valve.setter
+    def check_valve(self, value): 
+        self._check_valve = value
+
+    @property
+    def cv(self):
+        warn('cv is deprecated. Use check_valve instead', DeprecationWarning, stacklevel=2)
+        return self._check_valve
     @cv.setter
     def cv(self, value): 
-        self._cv = value
-        
+        warn('cv is deprecated. Use check_valve instead', DeprecationWarning, stacklevel=2)
+        self._check_valve = value
+
     @property
     def bulk_coeff(self):
         """float or None : if not None, then a pipe specific bulk reaction coefficient"""

--- a/wntr/network/elements.py
+++ b/wntr/network/elements.py
@@ -972,6 +972,9 @@ class Pipe(Link):
 
     @property
     def cv(self):
+        """bool : alias of ``check_valve``
+        
+        Deprecated - use ``check_valve`` instead"""
         warn('cv is deprecated. Use check_valve instead', DeprecationWarning, stacklevel=2)
         return self._check_valve
     @cv.setter

--- a/wntr/network/elements.py
+++ b/wntr/network/elements.py
@@ -974,7 +974,7 @@ class Pipe(Link):
     def cv(self):
         """bool : alias of ``check_valve``
         
-        Deprecated - use ``check_valve`` instead"""
+        Deprecated - use ``check_valve`` instead."""
         warn('cv is deprecated. Use check_valve instead', DeprecationWarning, stacklevel=2)
         return self._check_valve
     @cv.setter

--- a/wntr/network/elements.py
+++ b/wntr/network/elements.py
@@ -10,7 +10,7 @@ import math
 import six
 import copy
 from scipy.optimize import curve_fit, OptimizeWarning
-
+from warnings import warn
 from collections.abc import MutableSequence
 
 from .base import Node, Link, Registry, LinkStatus


### PR DESCRIPTION
To fix #468.

Deprecate Pipe.cv in favour of Pipe.check_valve (as pipe.check_valve is used more frequently already, and is clearer.) 
 
 
## Acknowledgement
By contributing to this software project, I acknowledge that I have reviewed the [software quality assurance guidelines](https://usepa.github.io/WNTR/developers.html) and that my contributions are submitted under the [Revised BSD License](https://usepa.github.io/WNTR/license.html). 
