### PR TITLE
Update wheel building to rename linux wheels

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -47,6 +47,15 @@ jobs:
           new_name=$(echo "$file" | sed 's/macosx_14_0/macosx_13_0/')
           mv "$file" "$new_name"
         done
+    - name: Fix linux wheel names # This is a bit dishonest, since the wheels are not properly repaired to be manylinux compatible. This is a (hopefully) temporary hack to get our wheels onto pypi. 
+      if: ${{ matrix.os == 'ubuntu-latest' }}
+      run: |
+        for file in ./wheelhouse/*.whl; do
+          [ -e "$file" ] || continue
+          new_file="${file/linux/manylinux2014}"
+          mv "$file" "$new_file"
+          echo "Renamed: $file -> $new_file"
+        done
     - name: Upload wheels
       uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
       with:


### PR DESCRIPTION
## Summary
This PR is intended to address the problem that our linux wheels are rejected by PYPI. This is because they are generic linux wheels, rather than complying to a manylinux standard. Previous attempts to repair the wheel to a proper manylinux standard have run into difficulties resulting from the compiled EPANET binaries. Since these binaries are out of our control, it is not possible to quickly resolve this issue.

By renaming our linux wheels to appear as manylinux wheels, pypi should accept them. It is important to recognize that this will likely cause issues on some systems which are not actually compatible with the linux wheel, despite the manylinux name. We have tested the wheel on common ubuntu environments (my personal machine (22.04), GH ubuntu-latest (I assume this is 24.X), and on Google Colab. By forcing the wheel name, these environments should be able to successfully install and use the latest WNTR release despite the current inability to properly repair the linux wheel to manylinux standard.

## Tests and documentation
As mentioned, the generic linux wheels have been tested on a handful of ubuntu systems to verify that they will work despite the failure to repair.
 
## Acknowledgement
By contributing to this software project, I acknowledge that I have reviewed the [software quality assurance guidelines](https://usepa.github.io/WNTR/developers.html) and that my contributions are submitted under the [Revised BSD License](https://usepa.github.io/WNTR/license.html). 
