### PR TITLE
Improve check valve validation and setting

### DIFF
--- a/wntr/network/elements.py
+++ b/wntr/network/elements.py
@@ -973,7 +973,8 @@ class Pipe(Link):
         elif value == False or value== 'False':
             self._check_valve = False
         else:
-            raise ValueError('check_valve must be True or False')
+            msg=f'check_valve must be True or False. Received {value} of type {type(value)}'
+            raise ValueError(msg)
 
 
     @property

--- a/wntr/network/elements.py
+++ b/wntr/network/elements.py
@@ -968,7 +968,13 @@ class Pipe(Link):
         return self._check_valve
     @check_valve.setter
     def check_valve(self, value): 
-        self._check_valve = value
+        if value == True or value == 'True':
+            self._check_valve = True
+        elif value == False or value== 'False':
+            self._check_valve = False
+        else:
+            raise ValueError('check_valve must be True or False')
+
 
     @property
     def cv(self):
@@ -976,11 +982,11 @@ class Pipe(Link):
         
         Deprecated - use ``check_valve`` instead."""
         warn('cv is deprecated. Use check_valve instead', DeprecationWarning, stacklevel=2)
-        return self._check_valve
+        return self.check_valve
     @cv.setter
     def cv(self, value): 
         warn('cv is deprecated. Use check_valve instead', DeprecationWarning, stacklevel=2)
-        self._check_valve = value
+        self.check_valve = value
 
     @property
     def bulk_coeff(self):

--- a/wntr/network/elements.py
+++ b/wntr/network/elements.py
@@ -968,9 +968,9 @@ class Pipe(Link):
         return self._check_valve
     @check_valve.setter
     def check_valve(self, value): 
-        if value == True or value == 'True':
+        if value == True or value == 'True' or value == '1':
             self._check_valve = True
-        elif value == False or value== 'False':
+        elif value == False or value == 'False' or value == '0':
             self._check_valve = False
         else:
             msg=f'check_valve must be True or False. Received {value} of type {type(value)}'

--- a/wntr/network/elements.py
+++ b/wntr/network/elements.py
@@ -7,7 +7,6 @@ import numpy as np
 import sys
 import logging
 import math
-import six
 import copy
 from scipy.optimize import curve_fit, OptimizeWarning
 from warnings import warn
@@ -591,21 +590,25 @@ class Tank(Node):
         return self._overflow
     @overflow.setter
     def overflow(self, value):
-        if isinstance(value, six.string_types):
+        if value == False or value is None:
+            self._overflow = False
+            return
+        if value == True:
+            self._overflow = True
+            return
+        
+        if isinstance(value, str):
             value = value.upper()
+            if value in ["NO", "FALSE", "0"]:
+                self._overflow = False
+                return
             if value in ["YES", "TRUE", "1"]:
-                value = True
-            elif value in ["NO", "FALSE", "0"]:
-                value = False
-            else:
-                raise ValueError('The overflow entry must "YES" or "NO"')
-        elif isinstance(value, int):
-            value = bool(value)
-        elif value is None:
-            value = False
-        elif not isinstance(value, bool):
-            raise ValueError('The overflow entry must be blank, "YES"/"NO", 1/0, of True/False')
-        self._overflow = value
+                self._overflow = True
+                return
+            
+        msg = f'overflow must be a boolean; a string "YES", "NO", "1", "0", "True" or "False"; or None. Received {value} of type {type(value)}'
+        raise ValueError(msg)
+
 
     @property
     def level(self):
@@ -968,13 +971,24 @@ class Pipe(Link):
         return self._check_valve
     @check_valve.setter
     def check_valve(self, value): 
-        if value == True or value == 'True' or value == '1':
-            self._check_valve = True
-        elif value == False or value == 'False' or value == '0':
+        if value == False or value is None:
             self._check_valve = False
-        else:
-            msg=f'check_valve must be True or False. Received {value} of type {type(value)}'
-            raise ValueError(msg)
+            return
+        if value == True:
+            self._check_valve = True
+            return
+
+        if isinstance(value, str):
+            value = value.upper()
+            if value in ["NO", "FALSE", "0"]:
+                self._check_valve = False
+                return
+            if value in ["YES", "TRUE", "1"]:
+                self._check_valve = True
+                return
+      
+        msg = f'check_valve must be a boolean; a string "YES", "NO", "1", "0", "True" or "False"; or None. Received {value} of type {type(value)}'
+        raise ValueError(msg)
 
 
     @property

--- a/wntr/network/model.py
+++ b/wntr/network/model.py
@@ -2373,8 +2373,7 @@ class LinkRegistry(Registry):
         assert isinstance(roughness, (int, float)), "roughness must be a float"
         assert isinstance(minor_loss, (int, float)), "minor_loss must be a float"
         assert isinstance(initial_status, (int, str, LinkStatus)), "initial_status must be an int, string or LinkStatus"
-        assert isinstance(check_valve, (str, int, bool)), "check_valve must be a Boolean"
-        check_valve = bool(int(check_valve))
+
         
         length = float(length)
         diameter = float(diameter)


### PR DESCRIPTION
Provide a summary of the proposed changes, describe tests and documentation, and review the acknowledgement below. 
 
## Summary
Include issues that are resolved by this pull request.  
Improved method of setting check_valve on pipes. Validation and conversion from string values 'True', 'False', '1' and '0' occurs within element rather than with add_pipe. This means when check_valve is set directly validation will occur.

Contributres to #422. This is also a step towards allowing use of geopandas >= 1.0.  This is because shapefile booleans seem to be returned as strings 'True' and 'False' rather than strings '1' and '0' so current normalisation with `check_valve = bool(int(check_valve))` fails. This resolves the following error when trying to use geopandas >= 1.0

```
>       check_valve = bool(int(check_valve))
E       ValueError: invalid literal for int() with base 10: 'False'
```

May also fix #475 

## Tests and documentation
Does not change the API functionality, covered by existing tests.
 
## Acknowledgement
By contributing to this software project, I acknowledge that I have reviewed the [software quality assurance guidelines](https://usepa.github.io/WNTR/developers.html) and that my contributions are submitted under the [Revised BSD License](https://usepa.github.io/WNTR/license.html). 
