### PR TITLE
__geo_interface__ support

### DIFF
--- a/wntr/network/elements.py
+++ b/wntr/network/elements.py
@@ -908,7 +908,7 @@ class Pipe(Link):
         self._reaction_rate = None
         
     def __repr__(self):
-        return "<Pipe '{}' from '{}' to '{}', length={}, diameter={}, roughness={}, minor_loss={}, check_valve={}, status={}>".format(self._link_name,
+        return "<Pipe '{}' from '{}' to '{}', length={}, diameter={}, roughness={}, minor_loss={}, check_valve={}, status={}>".format(self._name,
                        self.start_node, self.end_node, self.length, self.diameter, 
                        self.roughness, self.minor_loss, self.check_valve, str(self.status))
     
@@ -1302,7 +1302,7 @@ class HeadPump(Pump):
 #                                         # the _curve_coeffs were calculated
 
     def __repr__(self):
-        return "<Pump '{}' from '{}' to '{}', pump_type='{}', pump_curve={}, speed={}, status={}>".format(self._link_name,
+        return "<Pump '{}' from '{}' to '{}', pump_type='{}', pump_curve={}, speed={}, status={}>".format(self._name,
                    self.start_node, self.end_node, 'HEAD', self.pump_curve_name, 
                    self.speed_timeseries, str(self.status))
     
@@ -1325,8 +1325,8 @@ class HeadPump(Pump):
         return self._pump_curve_name
     @pump_curve_name.setter
     def pump_curve_name(self, name):
-        self._curve_reg.remove_usage(self._pump_curve_name, (self._link_name, 'Pump'))
-        self._curve_reg.add_usage(name, (self._link_name, 'Pump'))
+        self._curve_reg.remove_usage(self._pump_curve_name, (self._name, 'Pump'))
+        self._curve_reg.add_usage(name, (self._name, 'Pump'))
         self._curve_reg.set_curve_type(name, 'HEAD')
         self._pump_curve_name = name
         # delete the pump curve coefficients because they have to be recaulcated 
@@ -1515,7 +1515,7 @@ class PowerPump(Pump):
     """
 
     def __repr__(self):
-        return "<Pump '{}' from '{}' to '{}', pump_type='{}', power={}, speed={}, status={}>".format(self._link_name,
+        return "<Pump '{}' from '{}' to '{}', pump_type='{}', power={}, speed={}, status={}>".format(self._name,
                    self.start_node, self.end_node, 'POWER', self._base_power, 
                    self.speed_timeseries, str(self.status))
     
@@ -1538,7 +1538,7 @@ class PowerPump(Pump):
         return self._base_power
     @power.setter
     def power(self, value):
-        self._curve_reg.remove_usage(self._pump_curve_name, (self._link_name, 'Pump'))
+        self._curve_reg.remove_usage(self._pump_curve_name, (self._name, 'Pump'))
         self._base_power = value
 
 
@@ -1625,7 +1625,7 @@ class Valve(Link):
 
     def __repr__(self):
         fmt = "<Valve '{}' from '{}' to '{}', valve_type='{}', diameter={}, minor_loss={}, setting={}, status={}>"
-        return fmt.format(self._link_name,
+        return fmt.format(self._name,
                           self.start_node, self.end_node, self.__class__.__name__,
                           self.diameter, 
                           self.minor_loss, self.setting, str(self.status))
@@ -2037,8 +2037,8 @@ class GPValve(Valve):
         return self._headloss_curve_name
     @headloss_curve_name.setter
     def headloss_curve_name(self, name):
-        self._curve_reg.remove_usage(self._headloss_curve_name, (self._link_name, 'Valve'))
-        self._curve_reg.add_usage(name, (self._link_name, 'Valve'))
+        self._curve_reg.remove_usage(self._headloss_curve_name, (self._name, 'Valve'))
+        self._curve_reg.add_usage(name, (self._name, 'Valve'))
         self._curve_reg.set_curve_type(name, 'HEADLOSS')
         self._headloss_curve_name = name
     

--- a/wntr/tests/test_network.py
+++ b/wntr/tests/test_network.py
@@ -320,7 +320,7 @@ class TestNetworkMethods(unittest.TestCase):
         valve_list.sort()
         self.assertEqual(valve_list, ["v1"])
         for name, link in wn.links():
-            self.assertEqual(name, link._link_name)
+            self.assertEqual(name, link._name)
 
     def test_1_pt_head_curve(self):
         q2 = 10.0


### PR DESCRIPTION
## Summary
This changes adds `__geo_interface__` support: https://gist.github.com/sgillies/2217756

The geo_interface is a method of exchanging geospatial data between applications. For example, it makes it directly possible to read into geopandas:
```
import geopandas as gpd
gpd.GeoDataFrame.from_features(wn.junctions)
```

or with shapely:
```
from shapely.geometry import shape
shape(wn.links['link_name'])
```

or with any other package which supports geo_interface

As part of this I've changed added to the behaviour of `WaterNetworkModel.junctions` , pipes, etc. to act as a Mapping, which also implements the geo_interface, but which also maintains the existing behaviour when called. ( this means that their behaviour is more similar to WaterNetworkModel.nodes and links ).

This doesn't replace the gis modules (although it could be used to simplify the logic within to_qgis()). It also doesn't require any dependencies. 

As part of this I created a common class for both Node and Link to inherit from, and moved some of the shared methods over to it. In passing, I have also removed some other old uses of the `six` package and uses of `Object`.

## Tests and documentation
I have not yet written the tests and document - I will do some refinements, writing tests and  adding to the documentation if you agree in principle to the changes so far.
 
## Acknowledgement
By contributing to this software project, I acknowledge that I have reviewed the [software quality assurance guidelines](https://usepa.github.io/WNTR/developers.html) and that my contributions are submitted under the [Revised BSD License](https://usepa.github.io/WNTR/license.html). 
