### PR TITLE
Ad hoc signing of dylibs for Apple Silicon

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -33,6 +33,15 @@ jobs:
       if: ${{ matrix.os == 'macos-latest' || matrix.os == 'macOS-13'}}
       run: |
         brew reinstall libomp # EPANETMSX repo also has this line, maybe include? `brew link --force --overwrite libomp`
+    - name: Ad-hoc codesign for Apple Silicon
+      if: ${{ matrix.os == 'macos-latest' }}
+      run: |
+        dylib_path="wntr/epanet/libepanet/darwin-arm"
+        if [ -d "$dylib_path" ]; then
+          for file in "$dylib_path"/*; do
+            [ -e "$file" ] && codesign -f -s - "$file"
+          done
+        fi
     - name: Build wheels
       uses: pypa/cibuildwheel@79b0dd328794e1180a7268444d46cdf12e1abd01 # v2.21.0
       env:


### PR DESCRIPTION
 ## Summary
works around https://github.com/USEPA/WNTR/issues/494 by ad hoc signing the dylibs on Apple Silicon.

do note [limitations](https://developer.apple.com/documentation/macos-release-notes/macos-big-sur-11_0_1-universal-apps-release-notes) of ad hoc signing:

> However, given that these signatures do not bear any valid identity, binaries signed this way cannot pass through Gatekeeper.

this means this solution is not future proof if Gatekeeper becomes more aggressive on future versions of macOS. the best practice would be to sign with an Apple Developer certificate and ideally notarize. but given the additional resources that would take, i think this is a reasonable workaround for https://github.com/USEPA/WNTR/issues/494.

## Tests and documentation
once the CI for this PR runs, i'll inspect the produced wheels and make sure the dylibs are signed using `codesign --verify  --verbose`.

i didn't change any documentation.
 
## Acknowledgement
By contributing to this software project, I acknowledge that I have reviewed the [software quality assurance guidelines](https://usepa.github.io/WNTR/developers.html) and that my contributions are submitted under the [Revised BSD License](https://usepa.github.io/WNTR/license.html). 
