### PR TITLE
set default for pump power in from_dict

### DIFF
--- a/wntr/network/io.py
+++ b/wntr/network/io.py
@@ -226,7 +226,7 @@ def from_dict(d: dict, append=None):
                     link["start_node_name"],
                     link["end_node_name"],
                     pump_type=pump_type,
-                    pump_parameter=link.setdefault("power")
+                    pump_parameter=link.setdefault("power", 50.0)
                     if pump_type.lower() == "power"
                     else link.setdefault("pump_curve_name"),
                     speed=link.setdefault("base_speed", 1.0),


### PR DESCRIPTION
Provide a summary of the proposed changes, describe tests and documentation, and review the acknowledgement below. 
 
## Summary
pump power is one of the only properties which does not have a default in from_dict()

This change gives it a default value which matches with the default value when using WaterNetworkModel.add_pump() 

## Tests and documentation
Does not change documentation. 
 
## Acknowledgement
By contributing to this software project, I acknowledge that I have reviewed the [software quality assurance guidelines](https://usepa.github.io/WNTR/developers.html) and that my contributions are submitted under the [Revised BSD License](https://usepa.github.io/WNTR/license.html). 
