### PR TITLE
Element property float checking

### DIFF
--- a/wntr/network/elements.py
+++ b/wntr/network/elements.py
@@ -939,7 +939,7 @@ class Pipe(Link):
         return self._length
     @length.setter
     def length(self, value):
-        self._length = value
+        self._length = _get_positive_float(value, "Pipe length")
 
     @property
     def diameter(self):
@@ -947,15 +947,16 @@ class Pipe(Link):
         return self._diameter
     @diameter.setter
     def diameter(self, value):
-        self._diameter = value
+        self._diameter = _get_positive_float(value, "Pipe diameter")
 
     @property
     def roughness(self):
         """float : pipe roughness"""
-        return self._roughness 
+        return self._roughness
+
     @roughness.setter
     def roughness(self, value):
-        self._roughness = value
+        self._roughness = _get_positive_float(value, "Pipe roughness")
 
     @property
     def minor_loss(self):
@@ -963,7 +964,7 @@ class Pipe(Link):
         return self._minor_loss
     @minor_loss.setter
     def minor_loss(self, value):
-        self._minor_loss = value
+        self._minor_loss = _get_positive_or_zero_float(value, "Pipe minor loss")
 
     @property
     def check_valve(self):
@@ -1009,7 +1010,7 @@ class Pipe(Link):
         return self._bulk_coeff
     @bulk_coeff.setter
     def bulk_coeff(self, value):
-        self._bulk_coeff = value
+        self._bulk_coeff = _get_float_or_none(value, "Pipe bulk reaction coefficient")
 
     @property
     def wall_coeff(self):
@@ -1017,7 +1018,7 @@ class Pipe(Link):
         return self._wall_coeff
     @wall_coeff.setter
     def wall_coeff(self, value):
-        self._wall_coeff = value
+        self._wall_coeff = _get_float_or_none(value, "Pipe wall reaction coefficient")
 
     @property
     def status(self):
@@ -2740,3 +2741,63 @@ class Source(object):
         if self.species:
             ret['species'] = self.species
         return ret
+
+
+def _get_float(value, property_name: str) -> float:
+    """Transform a value to a float.
+
+    Raises ValueError if the value is not a float or convertible to float.
+    """
+    try:
+        return float(value)
+    except ValueError as e:
+        value_type = type(value).__name__
+        raise ValueError(
+            f"{property_name} must be a float or convertible to float. Received {value} of type {value_type}"
+        ) from e
+
+
+def _get_positive_or_zero_float(value, property_name: str) -> float:
+    """Transform a value to a float and check it is positive or zero.
+
+    Raises ValueError if the value is not a float or convertible to float,
+    or if the value is negative.
+    """
+    value = _get_float(value, property_name)
+
+    if value < 0:
+        raise ValueError(f"{property_name} must not be negative")
+
+    return value
+
+
+def _get_positive_float(value, property_name: str) -> float:
+    """Transform a value to a float and check it is positive.
+
+    Raises ValueError if the value is not a float or convertible to float,
+    or if the value is not positive.
+    """
+    value = _get_float(value, property_name)
+
+    if not value > 0:
+        raise ValueError(f"{property_name} must be positive")
+
+    return value
+
+
+def _get_float_or_none(value, property_name: str) -> float | None:
+    """Transform a value to a float, unless it is None in which case return None.
+
+    Raises ValueError if the value is not a float or convertible to float,
+    and is not None.
+    """
+    if value is None:
+        return None
+
+    try:
+        return float(value)
+    except ValueError as e:
+        value_type = type(value).__name__
+        raise ValueError(
+            f"{property_name} must be a float, convertible to float, or None. Received {value} of type {value_type}"
+        ) from e

--- a/wntr/network/elements.py
+++ b/wntr/network/elements.py
@@ -939,7 +939,7 @@ class Pipe(Link):
         return self._length
     @length.setter
     def length(self, value):
-        self._length = _get_positive_non_zero_float(value, "Pipe length")
+        self._length = _get_positive_or_zero_float(value, "Pipe length")
 
     @property
     def diameter(self):

--- a/wntr/network/elements.py
+++ b/wntr/network/elements.py
@@ -939,7 +939,7 @@ class Pipe(Link):
         return self._length
     @length.setter
     def length(self, value):
-        self._length = _get_positive_float(value, "Pipe length")
+        self._length = _get_positive_non_zero_float(value, "Pipe length")
 
     @property
     def diameter(self):
@@ -947,7 +947,7 @@ class Pipe(Link):
         return self._diameter
     @diameter.setter
     def diameter(self, value):
-        self._diameter = _get_positive_float(value, "Pipe diameter")
+        self._diameter = _get_positive_non_zero_float(value, "Pipe diameter")
 
     @property
     def roughness(self):
@@ -956,7 +956,7 @@ class Pipe(Link):
 
     @roughness.setter
     def roughness(self, value):
-        self._roughness = _get_positive_float(value, "Pipe roughness")
+        self._roughness = _get_positive_non_zero_float(value, "Pipe roughness")
 
     @property
     def minor_loss(self):
@@ -2750,7 +2750,7 @@ def _get_float(value, property_name: str) -> float:
     """
     try:
         return float(value)
-    except ValueError as e:
+    except (ValueError, TypeError) as e:
         value_type = type(value).__name__
         raise ValueError(
             f"{property_name} must be a float or convertible to float. Received {value} of type {value_type}"
@@ -2771,7 +2771,7 @@ def _get_positive_or_zero_float(value, property_name: str) -> float:
     return value
 
 
-def _get_positive_float(value, property_name: str) -> float:
+def _get_positive_non_zero_float(value, property_name: str) -> float:
     """Transform a value to a float and check it is positive.
 
     Raises ValueError if the value is not a float or convertible to float,
@@ -2780,7 +2780,7 @@ def _get_positive_float(value, property_name: str) -> float:
     value = _get_float(value, property_name)
 
     if not value > 0:
-        raise ValueError(f"{property_name} must be positive")
+        raise ValueError(f"{property_name} must be greater than zero")
 
     return value
 
@@ -2796,7 +2796,7 @@ def _get_float_or_none(value, property_name: str) -> float | None:
 
     try:
         return float(value)
-    except ValueError as e:
+    except (ValueError, TypeError) as e:
         value_type = type(value).__name__
         raise ValueError(
             f"{property_name} must be a float, convertible to float, or None. Received {value} of type {value_type}"

--- a/wntr/tests/test_network_elements.py
+++ b/wntr/tests/test_network_elements.py
@@ -5,6 +5,7 @@ import unittest
 from os.path import abspath, dirname, join
 from unittest import SkipTest
 
+import pytest
 import numpy as np
 import wntr
 import wntr.network.elements as elements
@@ -279,6 +280,43 @@ class TestElements(unittest.TestCase):
         self.assertTrue(
             not ("Fire_Flow" in node.demand_timeseries_list.category_list())
         )
+
+
+@pytest.mark.parametrize("value", [1.0, 1, "400", 2.71828])
+def test_positive_non_zero_float(value):
+    assert elements._get_positive_non_zero_float(value, "test") == float(value)
+
+
+@pytest.mark.parametrize("value", [0, "0", 0.0, "not_a_number", -1, -2.71828, [-1, 2]])
+def test_positive_non_zero_float_bad_value(value):
+    with pytest.raises(ValueError, match="test"):
+        elements._get_positive_non_zero_float(value, "test")
+
+
+@pytest.mark.parametrize("value", [0.0, 0, "0", 1.0, 1, "500", 0, 2.71828])
+def test_positive_or_zero_float(value):
+    assert elements._get_positive_or_zero_float(value, "test") == float(value)
+
+
+@pytest.mark.parametrize("value", ["not_a_number", -1, -2.71828, [-1, 2]])
+def test_positive_or_zero_float_bad_value(value):
+    with pytest.raises(ValueError, match="test"):
+        elements._get_positive_or_zero_float(value, "test")
+
+
+@pytest.mark.parametrize("value", [1.0, 1, "400", 2.71828, 0.0, 0, -1, -2.71828])
+def test_float_or_none_with_float(value):
+    assert elements._get_float_or_none(value, "test") == float(value)
+
+
+def test_float_or_none_with_none():
+    assert elements._get_float_or_none(None, "test") is None
+
+
+@pytest.mark.parametrize("value", ["not_a_number", [-1, 2]])
+def test_float_or_none_bad_value(value):
+    with pytest.raises(ValueError, match="test"):
+        elements._get_float_or_none(value, "test")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
More detailed checks on element properites of type float. 

For now only checks properties for pipe, but can easily be expanded.

Note that length being 0 will break epanet, but passes in wntrsimulator.
 
## Tests and documentation
Tests included
 
## Acknowledgement
By contributing to this software project, I acknowledge that I have reviewed the [software quality assurance guidelines](https://usepa.github.io/WNTR/developers.html) and that my contributions are submitted under the [Revised BSD License](https://usepa.github.io/WNTR/license.html). 
