### PR TITLE
Updated vertices setter to allow for list of lists

### DIFF
--- a/wntr/network/base.py
+++ b/wntr/network/base.py
@@ -540,18 +540,18 @@ class Link(six.with_metaclass(abc.ABCMeta, object)):
         
     @property
     def vertices(self):
-        """A list of curve points, in the direction of start node to end node.
+        """A list of interior vertex points for network links, in the direction of start node to end node.
         
-        The vertices should be listed as a list of (x,y) tuples when setting.
+        The vertices should be listed as a list of (x,y) tuples/lists when setting.
         """
         return self._vertices
     @vertices.setter
     def vertices(self, points):
         if not isinstance(points, list):
-            raise ValueError('vertices must be a list of 2-tuples')
+            raise ValueError('vertices must be a list')
         for pt in points:
-            if not isinstance(pt, tuple) or len(pt) != 2:
-                raise ValueError('vertices must be a list of 2-tuples')
+            if not isinstance(pt, (tuple, list)) or len(pt) != 2:
+                raise ValueError('vertex points must be a tuple or list with two values')
         self._vertices = points
     
     def to_dict(self):

--- a/wntr/tests/test_network.py
+++ b/wntr/tests/test_network.py
@@ -954,7 +954,7 @@ class TestNetworkIO_Dict(unittest.TestCase):
         self.wntr = wntr
 
         self.inp_file = join(ex_datadir, "Net3.inp")
-        self.inp_files = [join(ex_datadir, f) for f in ["Net1.inp", "Net2.inp", "Net3.inp", "Net6.inp"]]
+        self.inp_files = [join(ex_datadir, f) for f in ["Net1.inp", "Net2.inp", "Net3.inp", "Net6.inp", "ky10.inp"]]
 
     @classmethod
     def tearDownClass(self):


### PR DESCRIPTION
## Summary
This PR updates the vertices setter to allow for a list of lists, instead of just a list of tuples.  The change is needed to support reading in JSON files that do not store tuples.

## Tests and documentation
ky10.inp, which includes vertices, was added to the JSON test.
 
## Acknowledgement
By contributing to this software project, I acknowledge that I have reviewed the [software quality assurance guidelines](https://usepa.github.io/WNTR/developers.html) and that my contributions are submitted under the [Revised BSD License](https://usepa.github.io/WNTR/license.html). 
