### PR TITLE
Fix GPV curve conversion from Unit Headloss to Absolute Headloss

### DIFF
--- a/wntr/epanet/io.py
+++ b/wntr/epanet/io.py
@@ -845,7 +845,7 @@ class InpFile(object):
                 curve_points = []
                 for point in self.curves[curve_name]:
                     x = to_si(self.flow_units, point[0], HydParam.Flow)
-                    y = to_si(self.flow_units, point[1], HydParam.HeadLoss)
+                    y = to_si(self.flow_units, point[1], HydParam.HydraulicHead)
                     curve_points.append((x, y))
                 self.wn.add_curve(curve_name, 'HEADLOSS', curve_points)
                 valve_set = curve_name
@@ -962,7 +962,7 @@ class InpFile(object):
                 f.write(';HEADLOSS: {}\n'.format(curve_name).encode(sys_default_enc))
                 for point in curve.points:
                     x = from_si(self.flow_units, point[0], HydParam.Flow)
-                    y = from_si(self.flow_units, point[1], HydParam.HeadLoss)
+                    y = from_si(self.flow_units, point[1], HydParam.HydraulicHead)
                     f.write(_CURVE_ENTRY.format(name=curve_name, x=x, y=y, com=';').encode(sys_default_enc))
             else:
                 f.write(';UNKNOWN: {}\n'.format(curve_name).encode(sys_default_enc))


### PR DESCRIPTION
## Summary

To fix issue in #497 

Headloss curve for GPV valves incorrectly used the unit headloss (head/length) type for conversion when reading and writing inp files. Now uses head type instead.

## Tests and documentation
Not a new feature. 
 
## Acknowledgement
By contributing to this software project, I acknowledge that I have reviewed the [software quality assurance guidelines](https://usepa.github.io/WNTR/developers.html) and that my contributions are submitted under the [Revised BSD License](https://usepa.github.io/WNTR/license.html). 
