### PR TITLE
Pump efficiency curve treated like other curves

### DIFF
--- a/wntr/epanet/io.py
+++ b/wntr/epanet/io.py
@@ -1055,7 +1055,7 @@ class InpFile(object):
                         curve_points.append((x, y))
                     self.wn.add_curve(curve_name, 'EFFICIENCY', curve_points)
                     curve = self.wn.get_curve(curve_name)
-                    pump.efficiency = curve
+                    pump.efficiency_curve_name = curve_name
                 else:
                     logger.warning('Unknown entry in ENERGY section: %s', line)
             else:
@@ -1076,8 +1076,8 @@ class InpFile(object):
         lnames.sort()
         for pump_name in lnames:
             pump = wn.links[pump_name]
-            if pump.efficiency is not None:
-                f.write('PUMP {:10s} EFFIC   {:s}\n'.format(pump_name, pump.efficiency.name).encode(sys_default_enc))
+            if pump.efficiency_curve_name is not None:
+                f.write('PUMP {:10s} EFFIC   {:s}\n'.format(pump_name, pump.efficiency_curve_name).encode(sys_default_enc))
             if pump.energy_price is not None:
                 f.write('PUMP {:10s} PRICE   {:.4f}\n'.format(pump_name, to_si(self.flow_units, pump.energy_price, HydParam.Energy)).encode(sys_default_enc))
             if pump.energy_pattern is not None:

--- a/wntr/metrics/economic.py
+++ b/wntr/metrics/economic.py
@@ -291,7 +291,7 @@ def pump_power(flowrate, head, wn):
 
     efficiency_dict = {}
     for pump_name, pump in wn.pumps():
-        if pump.efficiency is None:
+        if pump.efficiency_curve_name is None:
             efficiency_dict[pump_name] = [wn.options.energy.global_efficiency/100.0 for i in time]
         else:
             raise NotImplementedError('WNTR does not support pump efficiency curves yet.')

--- a/wntr/network/base.py
+++ b/wntr/network/base.py
@@ -568,7 +568,7 @@ class Link(six.with_metaclass(abc.ABCMeta, object)):
         for k in dir(self):
             if not k.startswith('_') and k not in [
                 'flow', 'cv', 'friction_factor', 'headloss',
-                'quality', 'reaction_rate', 'setting', 'status', 'velocity', 'speed_timeseries',
+                'quality', 'reaction_rate', 'setting', 'status', 'velocity', 'speed_timeseries', 'efficiency'
             ]:
                 val = getattr(self, k)
                 if not isinstance(val, types.MethodType):

--- a/wntr/network/elements.py
+++ b/wntr/network/elements.py
@@ -1079,7 +1079,8 @@ class Pump(Link):
         initial_status
         initial_setting
         initial_quality
-        efficiency
+        efficiency_curve
+        efficiency_curve_name
         energy_price
         energy_pattern
         vertices
@@ -1111,7 +1112,7 @@ class Pump(Link):
                         "initial_status"]
     _optional_attributes = ["initial_quality",
                             "initial_setting",
-                            "efficiency",
+                            "efficiency_curve_name",
                             "energy_pattern",
                             "energy_price",
                             "vertices",

--- a/wntr/network/elements.py
+++ b/wntr/network/elements.py
@@ -1139,9 +1139,7 @@ class Pump(Link):
     def efficiency(self): 
         warn('The pump efficiency property is deprecated - use efficiency_curve instead', DeprecationWarning, stacklevel=2)
         return self.efficiency_curve
-    @efficiency.setter
-    def efficiency(self, value):
-        self._efficiency = value
+
 
     @property
     def efficiency_curve(self):

--- a/wntr/network/elements.py
+++ b/wntr/network/elements.py
@@ -1122,7 +1122,7 @@ class Pump(Link):
         self._speed_timeseries = TimeSeries(wn._pattern_reg, 1.0)
         self._base_power = None
         self._pump_curve_name = None
-        self._efficiency = None
+        self._efficiency_curve_name = None
         self._energy_price = None 
         self._energy_pattern = None
         self._outage_rule_name = name+'_outage'
@@ -1133,13 +1133,43 @@ class Pump(Link):
             return False
         return True
 
+    
     @property
     def efficiency(self): 
-        """Curve : pump efficiency"""
-        return self._efficiency
+        warn('The pump efficiency property is deprecated - use efficiency_curve instead', DeprecationWarning, stacklevel=2)
+        return self.efficiency_curve
     @efficiency.setter
     def efficiency(self, value):
         self._efficiency = value
+
+    @property
+    def efficiency_curve(self):
+        """The efficiency curve, if defined (read only)
+
+        Used for energy use calculations.
+
+        If not defined, the pump will use a default efficiency % value WaterNetworkModel.options.energy.global_efficiency.
+
+        Set this using the vol_curve_name.
+        """
+
+        if self.efficiency_curve_name is None:
+            return None
+        return self._curve_reg[self.efficiency_curve_name]
+
+    @property
+    def efficiency_curve_name(self):
+        """Name of the volume curve to use, or None
+        
+        Curve must be in the curve registry"""
+        return self._efficiency_curve_name
+    
+    @efficiency_curve_name.setter
+    def efficiency_curve_name(self, curve_name):
+        self._curve_reg.remove_usage(self._efficiency_curve_name, (self.name, 'Pump'))
+        self._curve_reg.add_usage(curve_name, (self.name, 'Pump'))
+        self._efficiency_curve_name = curve_name
+
 
     @property
     def energy_price(self):

--- a/wntr/network/io.py
+++ b/wntr/network/io.py
@@ -234,7 +234,7 @@ def from_dict(d: dict, append=None):
                     initial_status=link.setdefault("initial_status", "OPEN"),
                 )
                 p = wn.get_link(name)
-                p.efficiency = link.setdefault("efficiency")
+                p.efficiency_curve_name = link.setdefault("efficiency_curve_name")
                 p.energy_pattern = link.setdefault("energy_pattern")
                 p.energy_price = link.setdefault("energy_price")
                 p.initial_setting = link.setdefault("initial_setting")

--- a/wntr/tests/test_network.py
+++ b/wntr/tests/test_network.py
@@ -1003,6 +1003,28 @@ class TestNetworkIO_Dict(unittest.TestCase):
         assert junction2._leak_area == 1
         assert junction2._leak_discharge_coeff == 0.75
 
+    def test_pump_efficiencey_curve(self):
+        wn = wntr.network.WaterNetworkModel()
+        wn.add_junction('J1')
+        wn.add_junction('J2')
+        wn.add_pump('P1','J1','J2')
+        pump = wn.get_link('P1')
+        wn.add_curve('efficiency_curve', 'EFFICIENCY',[(0,0),(1,1)])
+        pump.efficiency_curve_name = 'efficiency_curve'
+
+
+        wn_dict = wn.to_dict()
+        wn2 = wntr.network.from_dict(wn_dict)
+
+        efficiency_curve = wn2.get_curve('efficiency_curve')
+
+        assert efficiency_curve is not None
+        assert efficiency_curve.points == [(0, 0), (1, 1)]
+
+        assert pump.efficiency_curve_name == 'efficiency_curve'
+        assert isinstance(pump.efficiency_curve, wntr.network.Curve)
+        assert pump.efficiency_curve.name == 'efficiency_curve'
+
 
 @unittest.skipIf(not has_geopandas,
                  "Cannot test GIS capabilities: geopandas is missing")


### PR DESCRIPTION
## Summary
Using pump.efficiency doesn't use the curve registry, and doesn't round trip on to_dict/from_dict.

See #517 

This deprecates pump.efficiency and creates pump.efficiency_curve and pump.efficiency_cure_name, which work in a similar way to other curves.

## Tests and documentation
Added to_dict / from_dict round trip test for efficiency
 
## Acknowledgement
By contributing to this software project, I acknowledge that I have reviewed the [software quality assurance guidelines](https://usepa.github.io/WNTR/developers.html) and that my contributions are submitted under the [Revised BSD License](https://usepa.github.io/WNTR/license.html). 
