### PR TITLE
Extend _read_control_lines() to handle EPANET rules

### DIFF
--- a/wntr/epanet/io.py
+++ b/wntr/epanet/io.py
@@ -3250,7 +3250,7 @@ def _read_control_line(line, wn, flow_units, control_name):
     else:
         element_name = current[1]
         
-        if current[0].upper() == 'LINK':
+        if current[0].upper() in ['LINK', 'PIPE', 'PUMP', 'VALVE']:
             element = wn.get_link(element_name)
         else:
             element = wn.get_node(element_name)

--- a/wntr/gis/geospatial.py
+++ b/wntr/gis/geospatial.py
@@ -290,7 +290,7 @@ def intersect(A, B, B_value=None, include_background=False, background_value=0):
         stats.loc[covered_length.isna(), 'weighted_mean'] = stats.loc[covered_length.isna(), 'mean']
         
         # No intersection, set weighted mean to NaN
-        stats.loc[stats['n']==0, 'weighted_mean'] = np.NaN
+        stats.loc[stats['n']==0, 'weighted_mean'] = np.nan
         
     stats.index.name = None
     

--- a/wntr/tests/test_network_controls.py
+++ b/wntr/tests/test_network_controls.py
@@ -786,9 +786,8 @@ class TestControlParsing(unittest.TestCase):
         self.assertEqual(action._value, True)
         
         # Check condition
-        self.assertEqual(control._condition._source_obj.name, "j1")
-        self.assertEqual(control._condition._source_attr, "leak_status")
-        self.assertEqual(control._condition._relation, self.wntr.network.controls.Comparison.eq)
+        self.assertEqual(control._condition._threshold, 5 * 3600)
+
         
     def test_invalid_rule(self):
         """Test invalid RULES format"""

--- a/wntr/tests/test_network_controls.py
+++ b/wntr/tests/test_network_controls.py
@@ -5,6 +5,7 @@ from os.path import abspath, dirname, join
 import copy
 
 import wntr
+from wntr.epanet.io import _read_control_line
 
 testdir = dirname(abspath(str(__file__)))
 test_datadir = join(testdir, "networks_for_testing")
@@ -587,6 +588,242 @@ class TestControlCombinations(unittest.TestCase):
                 self.assertAlmostEqual(results.link["flowrate"].at[t, "pipe1"], 0.0)
 
         self.assertEqual(flag1, True)
+        
+class TestControlParsing(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        import wntr
+        import numpy as np
+        self.wntr = wntr
+        self.np = np
+        
+        # Create a simple water network for testing
+        self.wn = wntr.network.WaterNetworkModel()
+        inp_file = join(test_datadir, "control_comb.inp")
+        self.wn = wntr.network.WaterNetworkModel(inp_file)
+        self.flow_units = wntr.epanet.util.FlowUnits['SI']
+
+        
+    @classmethod
+    def tearDownClass(self):
+        pass
+    
+    def test_controls_format_link_status_time(self):
+        """Test CONTROLS format: LINK element status AT TIME"""
+        line = "LINK pipe1 OPEN AT TIME 12"
+        control = _read_control_line(line, self.wn, self.flow_units, "test_control")
+        
+        # Check that it's a time control (presolve type)
+        self.assertEqual(control.epanet_control_type.name, "presolve")
+        # Check the condition is SimTimeCondition
+        self.assertIsInstance(control._condition, self.wntr.network.controls.SimTimeCondition)
+        # Check the action
+        action = control._then_actions[0]
+        self.assertEqual(action._target_obj.name, "pipe1")
+        self.assertEqual(action._attribute, "status")
+        self.assertEqual(action._value, self.wntr.network.LinkStatus.Opened)
+        # Check the time threshold
+        self.assertEqual(control._condition._threshold, 12 * 3600)  # 12 hours in seconds
+        
+    def test_controls_format_link_status_clocktime(self):
+        """Test CONTROLS format: LINK element status AT CLOCKTIME"""
+        line = "LINK pipe1 CLOSED AT CLOCKTIME 8:30 AM"
+        control = _read_control_line(line, self.wn, self.flow_units, "test_control")
+        
+        # Check that it's a time control (presolve type)
+        self.assertEqual(control.epanet_control_type.name, "presolve")
+        # Check the condition is TimeOfDayCondition
+        self.assertIsInstance(control._condition, self.wntr.network.controls.TimeOfDayCondition)
+        # Check the action
+        action = control._then_actions[0]
+        self.assertEqual(action._target_obj.name, "pipe1")
+        self.assertEqual(action._attribute, "status")
+        self.assertEqual(action._value, self.wntr.network.LinkStatus.Closed)
+        
+    def test_controls_format_link_status_conditional(self):
+        """Test CONTROLS format: LINK element status IF NODE condition"""
+        line = "LINK pipe1 CLOSED IF NODE tank1 BELOW 30"
+        control = _read_control_line(line, self.wn, self.flow_units, "test_control")
+        
+        # Check that it's a conditional control (pre_and_postsolve type for tank levels)
+        self.assertEqual(control.epanet_control_type.name, "pre_and_postsolve")
+        # Check the condition is TankLevelCondition (ValueCondition subclass)
+        self.assertIsInstance(control._condition, self.wntr.network.controls.TankLevelCondition)
+        # Check the action
+        action = control._then_actions[0]
+        self.assertEqual(action._target_obj.name, "pipe1")
+        self.assertEqual(action._attribute, "status")
+        self.assertEqual(action._value, self.wntr.network.LinkStatus.Closed)
+        # Check the condition details
+        self.assertEqual(control._condition._source_obj.name, "tank1")
+        self.assertEqual(control._condition._source_attr, "level")
+        
+    def test_controls_format_pump_setting(self):
+        """Test CONTROLS format: LINK pump setting"""
+        line = "LINK pump1 1.5 AT TIME 5"
+        control = _read_control_line(line, self.wn, self.flow_units, "test_control")
+        
+        # Check that it's a time control (presolve type)
+        self.assertEqual(control.epanet_control_type.name, "presolve")
+        # Check the action
+        action = control._then_actions[0]
+        self.assertEqual(action._target_obj.name, "pump1")
+        self.assertEqual(action._attribute, "base_speed")
+        self.assertEqual(action._value, 1.5)
+        
+    def test_rules_format_time_condition(self):
+        """Test RULES format: IF SYSTEM TIME THEN action"""
+        line = "IF SYSTEM TIME IS 6 THEN LINK pipe1 IS OPEN"
+        control = _read_control_line(line, self.wn, self.flow_units, "test_control")
+        
+        # Check that it's a time control (presolve type)
+        self.assertEqual(control.epanet_control_type.name, "presolve")
+        # Check the condition is SimTimeCondition
+        self.assertIsInstance(control._condition, self.wntr.network.controls.SimTimeCondition)
+        # Check the action
+        action = control._then_actions[0]
+        self.assertEqual(action._target_obj.name, "pipe1")
+        self.assertEqual(action._attribute, "status")
+        self.assertEqual(action._value, self.wntr.network.LinkStatus.Opened)
+        # Check the time threshold
+        self.assertEqual(control._condition._threshold, 6 * 3600)  # 6 hours in seconds
+        
+    def test_rules_format_clocktime_condition(self):
+        """Test RULES format: IF SYSTEM CLOCKTIME THEN action"""
+        line = "IF SYSTEM CLOCKTIME IS 9:00 AM THEN LINK pipe1 IS CLOSED"
+        control = _read_control_line(line, self.wn, self.flow_units, "test_control")
+        
+        # Check that it's a time control (presolve type)
+        self.assertEqual(control.epanet_control_type.name, "presolve")
+        # Check the condition is TimeOfDayCondition
+        self.assertIsInstance(control._condition, self.wntr.network.controls.TimeOfDayCondition)
+        # Check the action
+        action = control._then_actions[0]
+        self.assertEqual(action._target_obj.name, "pipe1")
+        self.assertEqual(action._attribute, "status")
+        self.assertEqual(action._value, self.wntr.network.LinkStatus.Closed)
+        
+    def test_rules_format_tank_level_condition(self):
+        """Test RULES format: IF TANK level condition THEN action"""
+        line = "IF TANK tank1 LEVEL BELOW 25 THEN LINK pump1 IS OPEN"
+        control = _read_control_line(line, self.wn, self.flow_units, "test_control")
+        
+        # Check that it's a conditional control (pre_and_postsolve type for tank levels)
+        self.assertEqual(control.epanet_control_type.name, "pre_and_postsolve")
+        # Check the condition is TankLevelCondition
+        self.assertIsInstance(control._condition, self.wntr.network.controls.TankLevelCondition)
+        # Check the action
+        action = control._then_actions[0]
+        self.assertEqual(action._target_obj.name, "pump1")
+        self.assertEqual(action._attribute, "status")
+        self.assertEqual(action._value, self.wntr.network.LinkStatus.Opened)
+        # Check the condition details
+        self.assertEqual(control._condition._source_obj.name, "tank1")
+        self.assertEqual(control._condition._source_attr, "level")
+        
+    def test_rules_format_junction_pressure_condition(self):
+        """Test RULES format: IF JUNCTION pressure condition THEN action"""
+        line = "IF JUNCTION j1 PRESSURE ABOVE 20 THEN LINK pipe1 IS CLOSED"
+        control = _read_control_line(line, self.wn, self.flow_units, "test_control")
+        
+        # Check that it's a conditional control (postsolve type for pressure conditions)
+        self.assertEqual(control.epanet_control_type.name, "postsolve")
+        # Check the condition is ValueCondition
+        self.assertIsInstance(control._condition, self.wntr.network.controls.ValueCondition)
+        # Check the action
+        action = control._then_actions[0]
+        self.assertEqual(action._target_obj.name, "pipe1")
+        self.assertEqual(action._attribute, "status")
+        self.assertEqual(action._value, self.wntr.network.LinkStatus.Closed)
+        # Check the condition details
+        self.assertEqual(control._condition._source_obj.name, "j1")
+        self.assertEqual(control._condition._source_attr, "pressure")
+        
+    def test_empty_line(self):
+        """Test empty line handling"""
+        line = ""
+        control = _read_control_line(line, self.wn, self.flow_units, "test_control")
+        self.assertIsNone(control)
+        
+    def test_comment_line(self):
+        """Test line with comment only"""
+        line = "; This is a comment"
+        control = _read_control_line(line, self.wn, self.flow_units, "test_control")
+        self.assertIsNone(control)
+        
+    def test_line_with_comment(self):
+        """Test line with control and comment"""
+        line = "LINK pipe1 OPEN AT TIME 12 ; This is a comment"
+        control = _read_control_line(line, self.wn, self.flow_units, "test_control")
+        
+        # Check that it's a time control (presolve type)
+        self.assertEqual(control.epanet_control_type.name, "presolve")
+        # Check the action
+        action = control._then_actions[0]
+        self.assertEqual(action._target_obj.name, "pipe1")
+        self.assertEqual(action._attribute, "status")
+        self.assertEqual(action._value, self.wntr.network.LinkStatus.Opened)
+        
+    def test_time_format_hours_minutes(self):
+        """Test time format with hours:minutes"""
+        line = "LINK pipe1 OPEN AT TIME 12:30"
+        control = _read_control_line(line, self.wn, self.flow_units, "test_control")
+        
+        # Check that it's a time control (presolve type)
+        self.assertEqual(control.epanet_control_type.name, "presolve")
+        expected_seconds = 12 * 3600 + 30 * 60  # 12 hours 30 minutes in seconds
+        self.assertEqual(control._condition._threshold, expected_seconds)
+        
+    def test_node_status_control(self):
+        """Test NODE element status control"""
+        line = "NODE j1 TRUE AT TIME 5"
+        control = _read_control_line(line, self.wn, self.flow_units, "test_control")
+        
+        # Check action
+        action = control._then_actions[0]
+        self.assertEqual(action._target_obj.name, "j1")
+        self.assertEqual(action._attribute, "leak_status")
+        self.assertEqual(action._value, True)
+        
+        # Check condition
+        self.assertEqual(control._condition._source_obj.name, "j1")
+        self.assertEqual(control._condition._source_attr, "leak_status")
+        self.assertEqual(control._condition._relation, self.wntr.network.controls.Comparison.eq)
+        
+    def test_invalid_rule(self):
+        """Test invalid RULES format"""
+        line = "IF SYSTEM TIME IS 6 LINK pipe1 IS OPEN"
+        with self.assertRaises(RuntimeError):
+            _read_control_line(line, self.wn, self.flow_units, "test_control")
+            
+    def test_operator_aliases(self):
+        """Test different operator aliases (ABOVE vs >, BELOW vs <)"""
+        line1 = "LINK pipe1 CLOSED IF NODE tank1 ABOVE 30"
+        line2 = "LINK pipe1 CLOSED IF NODE tank1 > 30"
+        
+        control1 = _read_control_line(line1, self.wn, self.flow_units, "test_control1")
+        control2 = _read_control_line(line2, self.wn, self.flow_units, "test_control2")
+        
+        # Both should create equivalent controls
+        self.assertEqual(control1.epanet_control_type.name, control2.epanet_control_type.name)
+        self.assertEqual(control1._condition._source_obj.name, control2._condition._source_obj.name)
+        self.assertEqual(control1._condition._source_attr, control2._condition._source_attr)
+
+    def test_existing_control_from_file(self):
+        """Test that the existing control from control_comb.inp is parsed correctly"""
+        # The file contains: LINK pipe1 CLOSED IF NODE tank1 BELOW 30
+        line = "LINK pipe1 CLOSED IF NODE tank1 BELOW 30"
+        control = _read_control_line(line, self.wn, self.flow_units, "test_control")
+        
+        # Check action
+        action = control._then_actions[0]
+        self.assertEqual(action._target_obj.name, "pipe1") 
+        self.assertEqual(action._attribute, "status")
+        self.assertEqual(action._value, self.wntr.network.LinkStatus.Closed)
+        # Check condition
+        self.assertEqual(control._condition._source_obj.name, "tank1")
+        self.assertEqual(control._condition._source_attr, "level")
+        self.assertEqual(control._condition._relation, self.wntr.network.controls.Comparison.lt)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
This PR extends the existing `_read_control_lines` function to parse control strings that use EPANET rule syntax. Previously, the function only handled EPANET control syntax.

## Tests and documentation
- [x] Add tests
- [x] Fix failing tests
 
## Acknowledgement
By contributing to this software project, I acknowledge that I have reviewed the [software quality assurance guidelines](https://usepa.github.io/WNTR/developers.html) and that my contributions are submitted under the [Revised BSD License](https://usepa.github.io/WNTR/license.html). 
