### PR TITLE
WNTR-convert utility script.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -104,4 +104,9 @@ setup(name=DISTNAME,
       zip_safe=False,
       install_requires=DEPENDENCIES,
       scripts=[],
+      entry_points={
+          'console_scripts': [
+              "wntr-convert = wntr.utils.convert:wntr_convert"
+          ]
+      },
       include_package_data=True)

--- a/wntr/utils/convert.py
+++ b/wntr/utils/convert.py
@@ -50,6 +50,7 @@ def wntr_convert(args=None):
                 parser.error(
                     f'Unknown file format "{infile.suffix}": expected one of ".inp", ".json"'
                 )
+        wn.convert_controls_to_rules()
         match outfile.suffix.lower():
             case ".inp":
                 wntr.network.io.write_inpfile(wn, str(outfile))

--- a/wntr/utils/convert.py
+++ b/wntr/utils/convert.py
@@ -5,7 +5,22 @@ import pathlib
 import wntr
 
 
-def __main__(args=None):
+def wntr_convert(args=None):
+    """Convert between WNTR input file formats. This is a command-line script.
+    Use the command ``wntr-convert --help`` for details.
+
+    File formats are determined from the filename extension. E.g., using the command
+        
+    ``wntr-convert myfile.inp myfile.json`` 
+        
+    will convert an EPANET INP-formatted file into a WNTR JSON-formatted file.
+
+    Parameters
+    ----------
+    args : Namespace
+        An :class:``argparse.Namespace`` object that can be called instead of reading
+        from the command line. Generally not used.
+    """
     parser = argparse.ArgumentParser(
         description="""Convert between WNTR input file formats.
         File formats are determined from the filename extension. E.g., using the command
@@ -26,27 +41,29 @@ def __main__(args=None):
             parser.error(
                 f'The path "{outfile.parent}" does not exist or is not a directory.'
             )
+        match infile.suffix.lower():
+            case ".inp":
+                wn = wntr.network.io.read_inpfile(str(infile))
+            case ".json":
+                wn = wntr.network.io.read_json(str(infile))
+            case _:
+                parser.error(
+                    f'Unknown file format "{infile.suffix}": expected one of ".inp", ".json"'
+                )
+        match outfile.suffix.lower():
+            case ".inp":
+                wntr.network.io.write_inpfile(wn, str(outfile))
+            case ".json":
+                wntr.network.io.write_json(wn, str(outfile), indent=2)
+            case _:
+                parser.error(
+                    f'Unknown file format "{outfile.suffix}": expected one of ".inp", ".json"'
+                )
     except IOError as e:
         parser.error(str(e))
-    match infile.suffix.lower():
-        case ".inp":
-            wn = wntr.network.io.read_inpfile(str(infile))
-        case ".json":
-            wn = wntr.network.io.read_json(str(infile))
-        case _:
-            parser.error(
-                f'Unknown file format "{infile.suffix}": expected one of ".inp", ".json"'
-            )
-    match outfile.suffix.lower():
-        case ".inp":
-            wntr.network.io.write_inpfile(wn, str(outfile))
-        case ".json":
-            wntr.network.io.write_json(wn, str(outfile), indent=2)
-        case _:
-            parser.error(
-                f'Unknown file format "{outfile.suffix}": expected one of ".inp", ".json"'
-            )
+    except Exception as e:
+        parser.error(str(e))
 
 
 if __name__ == "__main__":
-    __main__()
+    wntr_convert()

--- a/wntr/utils/convert.py
+++ b/wntr/utils/convert.py
@@ -1,0 +1,52 @@
+# coding: utf-8
+
+import argparse
+import pathlib
+import wntr
+
+
+def __main__(args=None):
+    parser = argparse.ArgumentParser(
+        description="""Convert between WNTR input file formats.
+        File formats are determined from the filename extension. E.g., using the command
+        
+        ``wntr-convert myfile.inp myfile.json`` 
+        
+        will convert an EPANET INP-formatted file into a WNTR JSON-formatted file."""
+    )
+    parser.add_argument("infile", help="Name of the file to convert.")
+    parser.add_argument("outfile", help="Name of the file to create.")
+    args = parser.parse_args(args)
+    infile = pathlib.Path(args.infile)
+    outfile = pathlib.Path(args.outfile)
+    try:
+        if not infile.exists():
+            parser.error(f'The file "{infile}" does not exist.')
+        if not outfile.parent.exists() and not outfile.parent.is_dir():
+            parser.error(
+                f'The path "{outfile.parent}" does not exist or is not a directory.'
+            )
+    except IOError as e:
+        parser.error(str(e))
+    match infile.suffix.lower():
+        case ".inp":
+            wn = wntr.network.io.read_inpfile(str(infile))
+        case ".json":
+            wn = wntr.network.io.read_json(str(infile))
+        case _:
+            parser.error(
+                f'Unknown file format "{infile.suffix}": expected one of ".inp", ".json"'
+            )
+    match outfile.suffix.lower():
+        case ".inp":
+            wntr.network.io.write_inpfile(wn, str(outfile))
+        case ".json":
+            wntr.network.io.write_json(wn, str(outfile), indent=2)
+        case _:
+            parser.error(
+                f'Unknown file format "{outfile.suffix}": expected one of ".inp", ".json"'
+            )
+
+
+if __name__ == "__main__":
+    __main__()


### PR DESCRIPTION
## Summary
This creates a small utility in wntr/utils that will convert between .inp and .json file formats.
This is a very small, but quite important, command-line utility for programs that need to call WNTR from outside the Python environment.

## Tests and documentation
Command line is self documenting.
 
## Acknowledgement
By contributing to this software project, I acknowledge that I have reviewed the [software quality assurance guidelines](https://usepa.github.io/WNTR/developers.html) and that my contributions are submitted under the [Revised BSD License](https://usepa.github.io/WNTR/license.html). 
