### PR TITLE
Remove macOS 13 wheel name fix step

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -49,13 +49,6 @@ jobs:
         CIBW_BUILD: cp310-* cp311-* cp312-* cp313-*
         CIBW_SKIP: "*-win32 *-manylinux_i686 pp* *-musllinux*"
         CIBW_REPAIR_WHEEL_COMMAND: '' # Skip repair step
-    - name: Fix macos13 wheel names # For some reason, they come out as macos14 instead of macos13
-      if: ${{ matrix.os == 'macOS-13'}} 
-      run: |
-        for file in ./wheelhouse/*.whl; do
-          new_name=$(echo "$file" | sed 's/macosx_14_0/macosx_13_0/')
-          mv "$file" "$new_name"
-        done
     - name: Fix linux wheel names # This is a bit dishonest, since the wheels are not properly repaired to be manylinux compatible. This is a (hopefully) temporary hack to get our wheels onto pypi. 
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |


### PR DESCRIPTION
Removed the step that fixes macOS 13 wheel names.
 
## Summary
There is an error when publishing the macOS 13 wheels to pypi (see [here](https://github.com/USEPA/WNTR/actions/runs/18663524791/job/53293363089) for details). Previously, macos 13 wheels produced by CIBW were named macos 14 for some reason. We manually renamed them to get around this bug, but this may be what causes the publish step to fail. This PR removes the renaming to see if CIBW correctly names the wheel so that we don't have to mess with it manually.

## Tests and documentation
New features require tests and documentation.
 
## Acknowledgement
By contributing to this software project, I acknowledge that I have reviewed the [software quality assurance guidelines](https://usepa.github.io/WNTR/developers.html) and that my contributions are submitted under the [Revised BSD License](https://usepa.github.io/WNTR/license.html). 
