### PR TITLE
Update wheel renaming step

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -49,21 +49,22 @@ jobs:
         CIBW_BUILD: cp310-* cp311-* cp312-* cp313-*
         CIBW_SKIP: "*-win32 *-manylinux_i686 pp* *-musllinux*"
         CIBW_REPAIR_WHEEL_COMMAND: '' # Skip repair step
-    - name: Fix macos13 wheel names # For some reason, they come out as macos14 instead of macos13
-      if: ${{ matrix.os == 'macOS-13'}} 
+    - name: Retag macOS 13 wheels
+      if: ${{ matrix.os == 'macOS-13' }}
       run: |
+        pip install wheel
         for file in ./wheelhouse/*.whl; do
-          new_name=$(echo "$file" | sed 's/macosx_14_0/macosx_13_0/')
-          mv "$file" "$new_name"
+          echo "Retagging $file → macosx_13_0"
+          wheel tags --remove --platform-tag macosx_14_0_x86_64 --platform-tag macosx_13_0_x86_64 "$file" || true
+          wheel tags --remove --platform-tag macosx_14_0_universal2 --platform-tag macosx_13_0_universal2 "$file" || true
         done
-    - name: Fix linux wheel names # This is a bit dishonest, since the wheels are not properly repaired to be manylinux compatible. This is a (hopefully) temporary hack to get our wheels onto pypi. 
+    - name: Retag Linux wheels
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |
+        pip install wheel
         for file in ./wheelhouse/*.whl; do
-          [ -e "$file" ] || continue
-          new_file="${file/linux/manylinux2014}"
-          mv "$file" "$new_file"
-          echo "Renamed: $file -> $new_file"
+          echo "Retagging $file → manylinux2014_x86_64"
+          wheel tags --remove --platform-tag linux_x86_64 --platform-tag manylinux2014_x86_64 "$file" || true
         done
     - name: Upload wheels
       uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0


### PR DESCRIPTION

## Summary
This PR updates the wheel renaming step in `build_tests.yml` to use `wheel tags` rather than just renaming the file. This should ensure that the internals of the wheel match the renaming, so that inconsistencies are avoided.

## Tests and documentation
New features require tests and documentation.
 
## Acknowledgement
By contributing to this software project, I acknowledge that I have reviewed the [software quality assurance guidelines](https://usepa.github.io/WNTR/developers.html) and that my contributions are submitted under the [Revised BSD License](https://usepa.github.io/WNTR/license.html). 
