### PR TITLE
PYPI publish metadata bugfix

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macOS-13]
+        os: [ubuntu-latest, windows-latest, macOS-13, macos-latest]
       fail-fast: false
     steps:
     - name: Set env variables to handle macOS-13
@@ -95,8 +95,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.11']
-        os: [macOS-13]
+        python-version: ['3.10', '3.11', '3.12', '3.13']
+        os: [ubuntu-latest, windows-latest, macOS-13, macos-latest]
       fail-fast: false
     steps:
     - name: Set up Python 
@@ -138,103 +138,103 @@ jobs:
         pip install -r requirements.txt
         pytest wntr/tests/ --ignore=wntr/tests/test_demos.py --ignore=wntr/tests/test_examples.py
   
-  # run_coverage:
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     matrix:
-  #       python-version: ['3.10', '3.11', '3.12', '3.13']
-  #       os: [windows-latest, macOS-13, ubuntu-latest, macos-latest]
-  #     fail-fast: false
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - name: Set up Python ${{ matrix.python-version }}
-  #     uses: actions/setup-python@v5
-  #     with:
-  #       python-version: ${{ matrix.python-version }}
-  #   - name: Set mpl backend on windows
-  #     if: ${{ matrix.os == 'windows-latest' }}
-  #     run: echo "MPLBACKEND=Agg" >> $env:GITHUB_ENV
-  #     shell: pwsh
-  #   - if: ${{ matrix.os == 'macos-latest' || matrix.os == 'macOS-13'}}
-  #     run: |
-  #       brew reinstall libomp
-  #   - name: Install dependencies
-  #     run: |
-  #       python --version
-  #       python -m pip install --upgrade pip
-  #       pip install -r requirements.txt
-  #       python -m pip install -e .
-  #   - name: Run Tests
-  #     if: ${{ matrix.os != 'macos-latest' }}
-  #     run: | 
-  #       coverage erase
-  #       coverage run --context=${{ matrix.os }}.py${{ matrix.python-version }} --source=wntr --omit="*/tests/*","*/sim/network_isolation/network_isolation.py","*/sim/aml/evaluator.py" -m pytest  --doctest-modules --doctest-glob="*.rst" wntr
-  #       coverage run --context=${{ matrix.os }}.py${{ matrix.python-version }} --source=wntr --omit="*/tests/*","*/sim/network_isolation/network_isolation.py","*/sim/aml/evaluator.py" --append -m pytest --doctest-glob="*.rst" documentation
-  #     env:
-  #       COVERAGE_FILE: .coverage.${{ matrix.python-version }}.${{ matrix.os }}
-  #   - name: Run Tests (ARM-processor)
-  #     if: ${{ matrix.os == 'macos-latest'}}
-  #     # doctests are not flexible enough to skip EPANET=v2.0 errors on ARM processor, so do not run doctests on ARM system
-  #     run: | 
-  #       coverage erase
-  #       coverage run --context=${{ matrix.os }}.py${{ matrix.python-version }} --source=wntr --omit="*/tests/*","*/sim/network_isolation/network_isolation.py","*/sim/aml/evaluator.py" -m pytest  --doctest-modules --doctest-glob="*.rst" wntr
-  #     env:
-  #       COVERAGE_FILE: .coverage.${{ matrix.python-version }}.${{ matrix.os }}
-  #   - name: Save coverage
-  #     uses: actions/upload-artifact@v4
-  #     with:
-  #       name: .coverage.${{ matrix.python-version }}.${{ matrix.os }}
-  #       path: .coverage.${{ matrix.python-version }}.${{ matrix.os }}
-  #       include-hidden-files: true
+  run_coverage:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13']
+        os: [ubuntu-latest, windows-latest, macOS-13, macos-latest]
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Set mpl backend on windows
+      if: ${{ matrix.os == 'windows-latest' }}
+      run: echo "MPLBACKEND=Agg" >> $env:GITHUB_ENV
+      shell: pwsh
+    - if: ${{ matrix.os == 'macos-latest' || matrix.os == 'macOS-13'}}
+      run: |
+        brew reinstall libomp
+    - name: Install dependencies
+      run: |
+        python --version
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        python -m pip install -e .
+    - name: Run Tests
+      if: ${{ matrix.os != 'macos-latest' }}
+      run: | 
+        coverage erase
+        coverage run --context=${{ matrix.os }}.py${{ matrix.python-version }} --source=wntr --omit="*/tests/*","*/sim/network_isolation/network_isolation.py","*/sim/aml/evaluator.py" -m pytest  --doctest-modules --doctest-glob="*.rst" wntr
+        coverage run --context=${{ matrix.os }}.py${{ matrix.python-version }} --source=wntr --omit="*/tests/*","*/sim/network_isolation/network_isolation.py","*/sim/aml/evaluator.py" --append -m pytest --doctest-glob="*.rst" documentation
+      env:
+        COVERAGE_FILE: .coverage.${{ matrix.python-version }}.${{ matrix.os }}
+    - name: Run Tests (ARM-processor)
+      if: ${{ matrix.os == 'macos-latest'}}
+      # doctests are not flexible enough to skip EPANET=v2.0 errors on ARM processor, so do not run doctests on ARM system
+      run: | 
+        coverage erase
+        coverage run --context=${{ matrix.os }}.py${{ matrix.python-version }} --source=wntr --omit="*/tests/*","*/sim/network_isolation/network_isolation.py","*/sim/aml/evaluator.py" -m pytest  --doctest-modules --doctest-glob="*.rst" wntr
+      env:
+        COVERAGE_FILE: .coverage.${{ matrix.python-version }}.${{ matrix.os }}
+    - name: Save coverage
+      uses: actions/upload-artifact@v4
+      with:
+        name: .coverage.${{ matrix.python-version }}.${{ matrix.os }}
+        path: .coverage.${{ matrix.python-version }}.${{ matrix.os }}
+        include-hidden-files: true
 
-  # combine_reports:
-  #   needs: [ run_coverage ]
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - name: Set up Python 
-  #     uses: actions/setup-python@v5
-  #     with:
-  #       python-version: 3.11
-  #   - uses: actions/checkout@v4
-  #   - name: Install coverage
-  #     run: |
-  #       python -m pip install --upgrade pip
-  #       pip install -r requirements.txt
-  #       python -m pip install -e .
-  #       pip install coveralls
-  #   - name: Download coverage artifacts from test matrix
-  #     uses: actions/download-artifact@v4
-  #     with:
-  #       pattern: .coverage.*.ubuntu-latest # coverage from other OS cause problems
-  #   - name: Setup coverage and combine reports
-  #     run: coverage combine .coverage.*.ubuntu-latest
-  #   - name: Create coverage report
-  #     run: |
-  #       echo "[paths]" > .coveragerc
-  #       echo "source = " >> .coveragerc
-  #       echo "    wntr/" >> .coveragerc
-  #       echo "    wntr\\" >> .coveragerc
-  #       echo "    D:\\a\\WNTR\\WNTR\\wntr" >> .coveragerc
-  #       echo "    /home/runner/work/WNTR/WNTR/wntr" >> .coveragerc
-  #       echo "    /Users/runner/work/WNTR/WNTR/wntr" >> .coveragerc
-  #       echo "    ${{ github.workspace }}/wntr" >> .coveragerc
-  #       coverage report
-  #       coverage json --pretty-print
-  #       coverage html --show-contexts
-  #   - name: Save coverage JSON
-  #     uses: actions/upload-artifact@v4
-  #     with:
-  #       name: coverage-json
-  #       path: coverage.json
-  #   - name: Save coverage html
-  #     uses: actions/upload-artifact@v4
-  #     with:
-  #       name: coverage-html
-  #       path: htmlcov
-  #   - name: Push to coveralls
-  #     run: coveralls --service=github --rcfile=.coveragerc
-  #     env:
-  #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  combine_reports:
+    needs: [ run_coverage ]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up Python 
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.11
+    - uses: actions/checkout@v4
+    - name: Install coverage
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        python -m pip install -e .
+        pip install coveralls
+    - name: Download coverage artifacts from test matrix
+      uses: actions/download-artifact@v4
+      with:
+        pattern: .coverage.*.ubuntu-latest # coverage from other OS cause problems
+    - name: Setup coverage and combine reports
+      run: coverage combine .coverage.*.ubuntu-latest
+    - name: Create coverage report
+      run: |
+        echo "[paths]" > .coveragerc
+        echo "source = " >> .coveragerc
+        echo "    wntr/" >> .coveragerc
+        echo "    wntr\\" >> .coveragerc
+        echo "    D:\\a\\WNTR\\WNTR\\wntr" >> .coveragerc
+        echo "    /home/runner/work/WNTR/WNTR/wntr" >> .coveragerc
+        echo "    /Users/runner/work/WNTR/WNTR/wntr" >> .coveragerc
+        echo "    ${{ github.workspace }}/wntr" >> .coveragerc
+        coverage report
+        coverage json --pretty-print
+        coverage html --show-contexts
+    - name: Save coverage JSON
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-json
+        path: coverage.json
+    - name: Save coverage html
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-html
+        path: htmlcov
+    - name: Push to coveralls
+      run: coveralls --service=github --rcfile=.coveragerc
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build_sdist:
     name: Build SDist artifact 📦
@@ -318,3 +318,4 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.PYPI_WNTR_API_TOKEN }}
+

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -288,7 +288,8 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
-          attestations: true
+          user: __token__
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           verbose: true
 
   publish-to-pypi:

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-13, macos-latest]
+        os: [macOS-13]
       fail-fast: false
     steps:
     - name: Set env variables to handle macOS-13
@@ -49,6 +49,10 @@ jobs:
         CIBW_BUILD: cp310-* cp311-* cp312-* cp313-*
         CIBW_SKIP: "*-win32 *-manylinux_i686 pp* *-musllinux*"
         CIBW_REPAIR_WHEEL_COMMAND: '' # Skip repair step
+    - name: Set up Python for twine verification
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
     - name: Install twine and verify wheels
       run: |
         python -m pip install --upgrade pip
@@ -85,8 +89,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
-        os: [windows-latest, macOS-13, macos-latest, ubuntu-latest]
+        python-version: ['3.11']
+        os: [macOS-13]
       fail-fast: false
     steps:
     - name: Set up Python 
@@ -128,103 +132,103 @@ jobs:
         pip install -r requirements.txt
         pytest wntr/tests/ --ignore=wntr/tests/test_demos.py --ignore=wntr/tests/test_examples.py
   
-  run_coverage:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
-        os: [windows-latest, macOS-13, ubuntu-latest, macos-latest]
-      fail-fast: false
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Set mpl backend on windows
-      if: ${{ matrix.os == 'windows-latest' }}
-      run: echo "MPLBACKEND=Agg" >> $env:GITHUB_ENV
-      shell: pwsh
-    - if: ${{ matrix.os == 'macos-latest' || matrix.os == 'macOS-13'}}
-      run: |
-        brew reinstall libomp
-    - name: Install dependencies
-      run: |
-        python --version
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        python -m pip install -e .
-    - name: Run Tests
-      if: ${{ matrix.os != 'macos-latest' }}
-      run: | 
-        coverage erase
-        coverage run --context=${{ matrix.os }}.py${{ matrix.python-version }} --source=wntr --omit="*/tests/*","*/sim/network_isolation/network_isolation.py","*/sim/aml/evaluator.py" -m pytest  --doctest-modules --doctest-glob="*.rst" wntr
-        coverage run --context=${{ matrix.os }}.py${{ matrix.python-version }} --source=wntr --omit="*/tests/*","*/sim/network_isolation/network_isolation.py","*/sim/aml/evaluator.py" --append -m pytest --doctest-glob="*.rst" documentation
-      env:
-        COVERAGE_FILE: .coverage.${{ matrix.python-version }}.${{ matrix.os }}
-    - name: Run Tests (ARM-processor)
-      if: ${{ matrix.os == 'macos-latest'}}
-      # doctests are not flexible enough to skip EPANET=v2.0 errors on ARM processor, so do not run doctests on ARM system
-      run: | 
-        coverage erase
-        coverage run --context=${{ matrix.os }}.py${{ matrix.python-version }} --source=wntr --omit="*/tests/*","*/sim/network_isolation/network_isolation.py","*/sim/aml/evaluator.py" -m pytest  --doctest-modules --doctest-glob="*.rst" wntr
-      env:
-        COVERAGE_FILE: .coverage.${{ matrix.python-version }}.${{ matrix.os }}
-    - name: Save coverage
-      uses: actions/upload-artifact@v4
-      with:
-        name: .coverage.${{ matrix.python-version }}.${{ matrix.os }}
-        path: .coverage.${{ matrix.python-version }}.${{ matrix.os }}
-        include-hidden-files: true
+  # run_coverage:
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     matrix:
+  #       python-version: ['3.10', '3.11', '3.12', '3.13']
+  #       os: [windows-latest, macOS-13, ubuntu-latest, macos-latest]
+  #     fail-fast: false
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - name: Set up Python ${{ matrix.python-version }}
+  #     uses: actions/setup-python@v5
+  #     with:
+  #       python-version: ${{ matrix.python-version }}
+  #   - name: Set mpl backend on windows
+  #     if: ${{ matrix.os == 'windows-latest' }}
+  #     run: echo "MPLBACKEND=Agg" >> $env:GITHUB_ENV
+  #     shell: pwsh
+  #   - if: ${{ matrix.os == 'macos-latest' || matrix.os == 'macOS-13'}}
+  #     run: |
+  #       brew reinstall libomp
+  #   - name: Install dependencies
+  #     run: |
+  #       python --version
+  #       python -m pip install --upgrade pip
+  #       pip install -r requirements.txt
+  #       python -m pip install -e .
+  #   - name: Run Tests
+  #     if: ${{ matrix.os != 'macos-latest' }}
+  #     run: | 
+  #       coverage erase
+  #       coverage run --context=${{ matrix.os }}.py${{ matrix.python-version }} --source=wntr --omit="*/tests/*","*/sim/network_isolation/network_isolation.py","*/sim/aml/evaluator.py" -m pytest  --doctest-modules --doctest-glob="*.rst" wntr
+  #       coverage run --context=${{ matrix.os }}.py${{ matrix.python-version }} --source=wntr --omit="*/tests/*","*/sim/network_isolation/network_isolation.py","*/sim/aml/evaluator.py" --append -m pytest --doctest-glob="*.rst" documentation
+  #     env:
+  #       COVERAGE_FILE: .coverage.${{ matrix.python-version }}.${{ matrix.os }}
+  #   - name: Run Tests (ARM-processor)
+  #     if: ${{ matrix.os == 'macos-latest'}}
+  #     # doctests are not flexible enough to skip EPANET=v2.0 errors on ARM processor, so do not run doctests on ARM system
+  #     run: | 
+  #       coverage erase
+  #       coverage run --context=${{ matrix.os }}.py${{ matrix.python-version }} --source=wntr --omit="*/tests/*","*/sim/network_isolation/network_isolation.py","*/sim/aml/evaluator.py" -m pytest  --doctest-modules --doctest-glob="*.rst" wntr
+  #     env:
+  #       COVERAGE_FILE: .coverage.${{ matrix.python-version }}.${{ matrix.os }}
+  #   - name: Save coverage
+  #     uses: actions/upload-artifact@v4
+  #     with:
+  #       name: .coverage.${{ matrix.python-version }}.${{ matrix.os }}
+  #       path: .coverage.${{ matrix.python-version }}.${{ matrix.os }}
+  #       include-hidden-files: true
 
-  combine_reports:
-    needs: [ run_coverage ]
-    runs-on: ubuntu-latest
-    steps:
-    - name: Set up Python 
-      uses: actions/setup-python@v5
-      with:
-        python-version: 3.11
-    - uses: actions/checkout@v4
-    - name: Install coverage
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        python -m pip install -e .
-        pip install coveralls
-    - name: Download coverage artifacts from test matrix
-      uses: actions/download-artifact@v4
-      with:
-        pattern: .coverage.*.ubuntu-latest # coverage from other OS cause problems
-    - name: Setup coverage and combine reports
-      run: coverage combine .coverage.*.ubuntu-latest
-    - name: Create coverage report
-      run: |
-        echo "[paths]" > .coveragerc
-        echo "source = " >> .coveragerc
-        echo "    wntr/" >> .coveragerc
-        echo "    wntr\\" >> .coveragerc
-        echo "    D:\\a\\WNTR\\WNTR\\wntr" >> .coveragerc
-        echo "    /home/runner/work/WNTR/WNTR/wntr" >> .coveragerc
-        echo "    /Users/runner/work/WNTR/WNTR/wntr" >> .coveragerc
-        echo "    ${{ github.workspace }}/wntr" >> .coveragerc
-        coverage report
-        coverage json --pretty-print
-        coverage html --show-contexts
-    - name: Save coverage JSON
-      uses: actions/upload-artifact@v4
-      with:
-        name: coverage-json
-        path: coverage.json
-    - name: Save coverage html
-      uses: actions/upload-artifact@v4
-      with:
-        name: coverage-html
-        path: htmlcov
-    - name: Push to coveralls
-      run: coveralls --service=github --rcfile=.coveragerc
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  # combine_reports:
+  #   needs: [ run_coverage ]
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - name: Set up Python 
+  #     uses: actions/setup-python@v5
+  #     with:
+  #       python-version: 3.11
+  #   - uses: actions/checkout@v4
+  #   - name: Install coverage
+  #     run: |
+  #       python -m pip install --upgrade pip
+  #       pip install -r requirements.txt
+  #       python -m pip install -e .
+  #       pip install coveralls
+  #   - name: Download coverage artifacts from test matrix
+  #     uses: actions/download-artifact@v4
+  #     with:
+  #       pattern: .coverage.*.ubuntu-latest # coverage from other OS cause problems
+  #   - name: Setup coverage and combine reports
+  #     run: coverage combine .coverage.*.ubuntu-latest
+  #   - name: Create coverage report
+  #     run: |
+  #       echo "[paths]" > .coveragerc
+  #       echo "source = " >> .coveragerc
+  #       echo "    wntr/" >> .coveragerc
+  #       echo "    wntr\\" >> .coveragerc
+  #       echo "    D:\\a\\WNTR\\WNTR\\wntr" >> .coveragerc
+  #       echo "    /home/runner/work/WNTR/WNTR/wntr" >> .coveragerc
+  #       echo "    /Users/runner/work/WNTR/WNTR/wntr" >> .coveragerc
+  #       echo "    ${{ github.workspace }}/wntr" >> .coveragerc
+  #       coverage report
+  #       coverage json --pretty-print
+  #       coverage html --show-contexts
+  #   - name: Save coverage JSON
+  #     uses: actions/upload-artifact@v4
+  #     with:
+  #       name: coverage-json
+  #       path: coverage.json
+  #   - name: Save coverage html
+  #     uses: actions/upload-artifact@v4
+  #     with:
+  #       name: coverage-html
+  #       path: htmlcov
+  #   - name: Push to coveralls
+  #     run: coveralls --service=github --rcfile=.coveragerc
+  #     env:
+  #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build_sdist:
     name: Build SDist artifact 📦

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -64,10 +64,16 @@ jobs:
     - name: Fix macos13 wheel names # For some reason, they come out as macos14 instead of macos13
       if: ${{ matrix.os == 'macOS-13'}} 
       run: |
+        echo "=== Before renaming ==="
+        ls -la ./wheelhouse/
         for file in ./wheelhouse/*.whl; do
+          echo "Original file: $file"
           new_name=$(echo "$file" | sed 's/macosx_14_0/macosx_13_0/')
+          echo "New name: $new_name"
           mv "$file" "$new_name"
         done
+        echo "=== After renaming ==="
+        ls -la ./wheelhouse/
     - name: Fix linux wheel names # This is a bit dishonest, since the wheels are not properly repaired to be manylinux compatible. This is a (hopefully) temporary hack to get our wheels onto pypi. 
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |
@@ -267,11 +273,23 @@ jobs:
         with:
           name: sdist
           path: dist
+      - name: Debug wheel files before upload
+        run: |
+          echo "=== Wheel files to upload ==="
+          ls -la dist/
+          echo "=== Wheel file details ==="
+          for wheel in dist/*.whl; do
+            echo "File: $wheel"
+            file "$wheel"
+            unzip -l "$wheel" | head -10
+            echo "---"
+          done
       - name: Publish to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
           attestations: true
+          verbose: true
 
   publish-to-pypi:
     name: Publish Python 🐍 distribution 📦 to PyPI
@@ -295,6 +313,7 @@ jobs:
           name: sdist
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish
         with:
-          attestations: true
+          user: __token__
+          password: ${{ secrets.PYPI_WNTR_API_TOKEN }}

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -54,6 +54,7 @@ jobs:
       with:
         python-version: '3.11'
     - name: Install twine and verify wheels
+      shell: bash
       run: |
         python -m pip install --upgrade pip
         pip install twine

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -43,12 +43,20 @@ jobs:
           done
         fi
     - name: Build wheels
-      uses: pypa/cibuildwheel@79b0dd328794e1180a7268444d46cdf12e1abd01 # v2.21.0
+      uses: pypa/cibuildwheel@v2.21.0
       env:
         CIBW_ENVIRONMENT: BUILD_WNTR_EXTENSIONS='true'
         CIBW_BUILD: cp310-* cp311-* cp312-* cp313-*
         CIBW_SKIP: "*-win32 *-manylinux_i686 pp* *-musllinux*"
         CIBW_REPAIR_WHEEL_COMMAND: '' # Skip repair step
+    - name: Install twine and verify wheels
+      run: |
+        python -m pip install --upgrade pip
+        pip install twine
+        for wheel in ./wheelhouse/*.whl; do
+          echo "Verifying wheel: $wheel"
+          twine check "$wheel"
+        done
     - name: Fix macos13 wheel names # For some reason, they come out as macos14 instead of macos13
       if: ${{ matrix.os == 'macOS-13'}} 
       run: |
@@ -66,7 +74,7 @@ jobs:
           echo "Renamed: $file -> $new_file"
         done
     - name: Upload wheels
-      uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
+      uses: actions/upload-artifact@v4
       with:
         name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
         path: ./wheelhouse/*.whl
@@ -233,6 +241,34 @@ jobs:
           name: sdist
           path: dist/*.tar.gz
 
+  publish-to-testpypi:
+    name: Publish Python 🐍 distribution 📦 to TestPyPI
+    needs: [build_sdist, test_wheels]
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/project/wntr
+    permissions:
+      id-token: write
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
+    steps:
+      - name: Download wheel artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: cibw-*
+          path: dist
+          merge-multiple: true
+      - name: Download SDist artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: sdist
+          path: dist
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          attestations: true
+
   publish-to-pypi:
     name: Publish Python 🐍 distribution 📦 to PyPI
     needs: [build_sdist, test_wheels]
@@ -244,7 +280,7 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     steps:
       - name: Download wheel artifacts
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        uses: actions/download-artifact@v4
         with:
           pattern: cibw-*
           path: dist
@@ -255,7 +291,6 @@ jobs:
           name: sdist
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@0ab0b79471669eb3a4d647e625009c62f9f3b241 # release/v1
+      - uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
-          password: ${{ secrets.PYPI_WNTR_API_TOKEN }}
+          attestations: true

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -314,7 +314,7 @@ jobs:
           name: sdist
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish
+      - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_WNTR_API_TOKEN }}

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -260,7 +260,7 @@ jobs:
       url: https://test.pypi.org/project/wntr
     permissions:
       id-token: write
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
+    if: github.event_name == 'workflow_dispatch'
     steps:
       - name: Download wheel artifacts
         uses: actions/download-artifact@v4

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ if build:
     extension_modules.append(aml_core_ext)
     extension_modules.append(network_isolation_ext)
 
-DISTNAME = 'kbonney-WNTR'
+DISTNAME = 'wntr'
 PACKAGES = find_packages()
 EXTENSIONS = extension_modules
 DESCRIPTION = 'Water Network Tool for Resilience'

--- a/setup.py
+++ b/setup.py
@@ -79,8 +79,15 @@ file_dir = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(file_dir, 'README.md'), encoding='utf-8') as f:
     LONG_DESCRIPTION = f.read()
 
-# Use a stable development version
-VERSION = "1.4.0rc3"
+# get version from __init__.py
+with open(os.path.join(file_dir, 'wntr', '__init__.py')) as f:
+    version_file = f.read()
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        VERSION = version_match.group(1)
+    else:
+        raise RuntimeError("Unable to find version string.")
 
 print(extension_modules)
 

--- a/setup.py
+++ b/setup.py
@@ -79,15 +79,11 @@ file_dir = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(file_dir, 'README.md'), encoding='utf-8') as f:
     LONG_DESCRIPTION = f.read()
 
-# get version from __init__.py
-with open(os.path.join(file_dir, 'wntr', '__init__.py')) as f:
-    version_file = f.read()
-    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
-                              version_file, re.M)
-    if version_match:
-        VERSION = version_match.group(1)
-    else:
-        raise RuntimeError("Unable to find version string.")
+import datetime
+
+# Generate a unique version based on timestamp
+timestamp = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
+VERSION = f"0.0.1.dev{timestamp}"
 
 print(extension_modules)
 

--- a/setup.py
+++ b/setup.py
@@ -79,11 +79,8 @@ file_dir = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(file_dir, 'README.md'), encoding='utf-8') as f:
     LONG_DESCRIPTION = f.read()
 
-import datetime
-
-# Generate a unique version based on timestamp
-timestamp = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
-VERSION = f"0.0.1.dev{timestamp}"
+# Use a stable development version
+VERSION = "1.4.0rc3"
 
 print(extension_modules)
 

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ if build:
     extension_modules.append(aml_core_ext)
     extension_modules.append(network_isolation_ext)
 
-DISTNAME = 'wntr'
+DISTNAME = 'kbonney-WNTR'
 PACKAGES = find_packages()
 EXTENSIONS = extension_modules
 DESCRIPTION = 'Water Network Tool for Resilience'


### PR DESCRIPTION
## Summary
This PR fixes the pypi publishing bug. The main issue ended up being related to pinned versions of the pypi release action, which caused a bug with metadata verification. From my testing on TestPYPI, the wheels should publish correctly now.

Additionally, a twine wheel check has been added to our workflow to help us catch issues with our wheels early on and the option to publish to testpypi via workflow dispatch has also been included

## Tests and documentation
n/a
 
## Acknowledgement
By contributing to this software project, I acknowledge that I have reviewed the [software quality assurance guidelines](https://usepa.github.io/WNTR/developers.html) and that my contributions are submitted under the [Revised BSD License](https://usepa.github.io/WNTR/license.html). 
