### PR TITLE
Fix pkg_resources deprecation

### DIFF
--- a/wntr/epanet/msx/toolkit.py
+++ b/wntr/epanet/msx/toolkit.py
@@ -16,7 +16,7 @@ import platform
 import sys
 from typing import Union
 
-if sys.version_info <= (3, 11):
+if sys.version_info[0:2] <= (3, 11):
     from pkg_resources import resource_filename
 else:
     from importlib.resources import files
@@ -49,7 +49,7 @@ class MSXepanet(ENepanet):
         self.msxfile = msxfile
 
         try:
-            if sys.version_info <= (3, 11):
+            if sys.version_info[0:2] <= (3, 11):
 
                 if os.name in ["nt", "dos"]:
                     libepanet = resource_filename(__name__, "../libepanet/windows-x64/epanet2.dll")

--- a/wntr/epanet/toolkit.py
+++ b/wntr/epanet/toolkit.py
@@ -10,7 +10,7 @@ import platform
 import sys
 from ctypes import byref
 
-if sys.version_info <= (3, 11):
+if sys.version_info[0:2] <= (3, 11):
     from pkg_resources import resource_filename
 else:
     from importlib.resources import files
@@ -108,7 +108,7 @@ class ENepanet:
         self.binfile = binfile
 
         try:
-            if sys.version_info <= (3, 11):
+            if sys.version_info[0:2] <= (3, 11):
                 if float(version) == 2.0:
                     libname = libepanet.replace('epanet22.','epanet20.')
                     if 'arm' in platform.platform():

--- a/wntr/library/msx/_msxlibrary.py
+++ b/wntr/library/msx/_msxlibrary.py
@@ -21,7 +21,7 @@ import logging
 import os, sys
 from typing import Any, ItemsView, Iterator, KeysView, List, Tuple, Union, ValuesView
 
-if sys.version_info <= (3, 11):
+if sys.version_info[0:2] <= (3, 11):
     from pkg_resources import resource_filename
 else:
     from importlib.resources import files
@@ -102,7 +102,7 @@ class MsxLibrary:
         self.__data = dict()
 
         if include_builtins:
-            if sys.version_info <= (3, 11):
+            if sys.version_info[0:2] <= (3, 11):
                 default_path = os.path.abspath(resource_filename(__name__, '.'))
             else:
                 default_path = os.path.abspath(files('wntr.library.msx').joinpath('.'))


### PR DESCRIPTION
This fix takes the pkg_resources out of the requirements for python 3.12+ but continues to use it for 3.11-. The new mechanism, while it is said to work for 3.10 and 3.11, has proven not to work due to import loops(?). This fix implements a switch based on the system python version.