### PR TITLE
Cap pandas requirement below 3.0

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -19,18 +19,18 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-13, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-15-intel, macos-latest]
       fail-fast: false
     steps:
-    - name: Set env variables to handle macOS-13
-      if: ${{ matrix.os == 'macOS-13'}}
+    - name: Set env variables to handle macOS-15
+      if: ${{ matrix.os == 'macos-15-intel'}}
       run: |
-        echo "MACOSX_DEPLOYMENT_TARGET=13.0" >> $GITHUB_ENV
-        echo "PLAT=macosx-13.0-universal2" >> $GITHUB_ENV
+        echo "MACOSX_DEPLOYMENT_TARGET=15.0" >> $GITHUB_ENV
+        echo "PLAT=macosx-15.0-universal2" >> $GITHUB_ENV
     - name: Checkout repository
       uses: actions/checkout@v4
     - name: Install libomp on macos
-      if: ${{ matrix.os == 'macos-latest' || matrix.os == 'macOS-13'}}
+      if: ${{ matrix.os == 'macos-latest' || matrix.os == 'macos-15-intel'}}
       run: |
         brew reinstall libomp # EPANETMSX repo also has this line, maybe include? `brew link --force --overwrite libomp`
     - name: Ad-hoc codesign for Apple Silicon
@@ -62,19 +62,19 @@ jobs:
           echo "Verifying wheel: $wheel"
           twine check "$wheel"
         done
-    - name: Fix macos13 wheel names # For some reason, they come out as macos14 instead of macos13
-      if: ${{ matrix.os == 'macOS-13'}} 
-      run: |
-        echo "=== Before renaming ==="
-        ls -la ./wheelhouse/
-        for file in ./wheelhouse/*.whl; do
-          echo "Original file: $file"
-          new_name=$(echo "$file" | sed 's/macosx_14_0/macosx_13_0/')
-          echo "New name: $new_name"
-          mv "$file" "$new_name"
-        done
-        echo "=== After renaming ==="
-        ls -la ./wheelhouse/
+    # - name: Fix macos15 wheel names # For some reason, they come out as macos14 instead of macos15
+    #   if: ${{ matrix.os == 'macos-15-intel'}} 
+    #   run: |
+    #     echo "=== Before renaming ==="
+    #     ls -la ./wheelhouse/
+    #     for file in ./wheelhouse/*.whl; do
+    #       echo "Original file: $file"
+    #       new_name=$(echo "$file" | sed 's/macosx_14_0/macosx_15_0/')
+    #       echo "New name: $new_name"
+    #       mv "$file" "$new_name"
+    #     done
+    #     echo "=== After renaming ==="
+    #     ls -la ./wheelhouse/
     - name: Fix linux wheel names # This is a bit dishonest, since the wheels are not properly repaired to be manylinux compatible. This is a (hopefully) temporary hack to get our wheels onto pypi. 
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |
@@ -97,7 +97,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13']
-        os: [ubuntu-latest, windows-latest, macOS-13, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-15-intel, macos-latest]
       fail-fast: false
     steps:
     - name: Set up Python 
@@ -131,7 +131,7 @@ jobs:
       if: ${{ matrix.os == 'windows-latest' }}
       run: echo "MPLBACKEND=Agg" >> $env:GITHUB_ENV
       shell: pwsh
-    - if: ${{ matrix.os == 'macos-latest' || matrix.os == 'macOS-13'}}
+    - if: ${{ matrix.os == 'macos-latest' || matrix.os == 'macos-15-intel'}}
       run: |
         brew reinstall libomp
     - name: Test wntr
@@ -144,7 +144,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13']
-        os: [ubuntu-latest, windows-latest, macOS-13, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-15-intel, macos-latest]
       fail-fast: false
     steps:
     - uses: actions/checkout@v4
@@ -156,7 +156,7 @@ jobs:
       if: ${{ matrix.os == 'windows-latest' }}
       run: echo "MPLBACKEND=Agg" >> $env:GITHUB_ENV
       shell: pwsh
-    - if: ${{ matrix.os == 'macos-latest' || matrix.os == 'macOS-13'}}
+    - if: ${{ matrix.os == 'macos-latest' || matrix.os == 'macos-15-intel'}}
       run: |
         brew reinstall libomp
     - name: Install dependencies

--- a/documentation/gis.rst
+++ b/documentation/gis.rst
@@ -959,7 +959,7 @@ connected WaterNetworkModel.  This assumes that all start and end nodes are Junc
     >>> np.random.seed(123)
     >>> disconnected_pipes = original_pipes[['diameter', 'length', 'geometry']]
     >>> for i, line in disconnected_pipes.iterrows():
-    ...     angle = np.random.uniform(-5,5,1)
+    ...     angle = np.random.uniform(-5,5)
     ...     geom = gpd.GeoSeries(line['geometry'])
     ...     geom = geom.rotate(angle)
     ...     geom = geom.scale(0.9, 0.9)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 numpy>=2.2.6 
 scipy
 networkx
-pandas
+pandas<3.0
 matplotlib
 setuptools
 

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ AUTHOR = 'WNTR Developers'
 MAINTAINER_EMAIL = 'kaklise@sandia.gov'
 LICENSE = 'Revised BSD'
 URL = 'https://github.com/USEPA/WNTR'
-DEPENDENCIES = ['numpy>=2.2.6 ', 'scipy', 'networkx', 'pandas', 'matplotlib', 'setuptools']
+DEPENDENCIES = ['numpy>=2.2.6 ', 'scipy', 'networkx', 'pandas<3.0', 'matplotlib', 'setuptools']
 
 # use README file as the long description
 file_dir = os.path.abspath(os.path.dirname(__file__))

--- a/wntr/tests/test_gis.py
+++ b/wntr/tests/test_gis.py
@@ -340,7 +340,7 @@ class TestConnectLines(unittest.TestCase):
         # Create imperfect pipe data
         disconnected_pipes = original_pipes.copy()
         for i, line in disconnected_pipes.iterrows():
-            angle = np.random.uniform(-5,5,1)
+            angle = np.random.uniform(-5,5)
             geom = gpd.GeoSeries(line['geometry'])
             geom = geom.rotate(angle)
             geom = geom.scale(0.9, 0.9)


### PR DESCRIPTION
## Summary
This PR places a cap on the installation requirement of pandas to below 3.0. This is in response to #547 and the first step in preparing WNTR for the new release of pandas.

To get tests passing this PR additionally does the following:
- Fixes numpy scalar vs array bug that cropped up in a few places.
- Migrates from macOS 13 wheels to macOS 15 wheels, as macOS 13 is no longer supported.

## Tests and documentation
 
## Acknowledgement
By contributing to this software project, I acknowledge that I have reviewed the [software quality assurance guidelines](https://usepa.github.io/WNTR/developers.html) and that my contributions are submitted under the [Revised BSD License](https://usepa.github.io/WNTR/license.html). 
