### PR TITLE
Fix pkg_resources deprecation and CI build failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools<69.5.1", "numpy>=2.2.6 "]
+requires = ["setuptools", "numpy>=2.2.6"]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "numpy>=2.2.6 "]
+requires = ["setuptools<69.5.1", "numpy>=2.2.6 "]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ scipy
 networkx
 pandas>=2.0
 matplotlib
-setuptools
+setuptools<69.5.1
 
 # Optional
 plotly<6.0

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ AUTHOR = 'WNTR Developers'
 MAINTAINER_EMAIL = 'kaklise@sandia.gov'
 LICENSE = 'Revised BSD'
 URL = 'https://github.com/USEPA/WNTR'
-DEPENDENCIES = ['numpy>=2.2.6 ', 'scipy', 'networkx', 'pandas>=2.0', 'matplotlib', 'setuptools']
+DEPENDENCIES = ['numpy>=2.2.6 ', 'scipy', 'networkx', 'pandas>=2.0', 'matplotlib', 'setuptools<69.5.1']
 
 # use README file as the long description
 file_dir = os.path.abspath(os.path.dirname(__file__))

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ AUTHOR = 'WNTR Developers'
 MAINTAINER_EMAIL = 'kaklise@sandia.gov'
 LICENSE = 'Revised BSD'
 URL = 'https://github.com/USEPA/WNTR'
-DEPENDENCIES = ['numpy>=2.2.6 ', 'scipy', 'networkx', 'pandas>=2.0', 'matplotlib', 'setuptools<69.5.1']
+DEPENDENCIES = ['numpy>=2.2.6', 'scipy', 'networkx', 'pandas>=2.0', 'matplotlib']
 
 # use README file as the long description
 file_dir = os.path.abspath(os.path.dirname(__file__))

--- a/wntr/epanet/msx/toolkit.py
+++ b/wntr/epanet/msx/toolkit.py
@@ -26,7 +26,6 @@ from .exceptions import (MSX_ERROR_CODES, EpanetMsxException, MSXKeyError,
 
 logger = logging.getLogger(__name__)
 
-epanet_toolkit = "wntr.epanet.toolkit"
 
 class MSXepanet(ENepanet):
     def __init__(self, inpfile="", rptfile="", binfile="", msxfile=""):
@@ -47,25 +46,25 @@ class MSXepanet(ENepanet):
 
         try:
             if os.name in ["nt", "dos"]:
-                libepanet = files(epanet_toolkit).joinpath("libepanet/windows-x64/epanet2.dll")
-                libmsx = files(epanet_toolkit).joinpath("libepanet/windows-x64/epanetmsx.dll")
+                libepanet = files('wntr.epanet').joinpath("libepanet/windows-x64/epanet2.dll")
+                libmsx = files('wntr.epanet').joinpath("libepanet/windows-x64/epanetmsx.dll")
             elif sys.platform in ["darwin"]:
                 if 'arm' in platform.platform().lower():
-                    libepanet = files(epanet_toolkit).joinpath("libepanet/darwin-arm/libepanet2.dylib")
-                    libmsx = files(epanet_toolkit).joinpath("libepanet/darwin-arm/libepanetmsx.dylib")
+                    libepanet = files('wntr.epanet').joinpath("libepanet/darwin-arm/libepanet2.dylib")
+                    libmsx = files('wntr.epanet').joinpath("libepanet/darwin-arm/libepanetmsx.dylib")
                 else:
-                    libepanet = files(epanet_toolkit).joinpath("libepanet/darwin-x64/libepanet2.dylib")
-                    libmsx = files(epanet_toolkit).joinpath("libepanet/darwin-x64/libepanetmsx.dylib")
+                    libepanet = files('wntr.epanet').joinpath("libepanet/darwin-x64/libepanet2.dylib")
+                    libmsx = files('wntr.epanet').joinpath("libepanet/darwin-x64/libepanetmsx.dylib")
             else:
-                libepanet = files(epanet_toolkit).joinpath("libepanet/linux-x64/libepanet2.so")
-                libmsx = files(epanet_toolkit).joinpath("libepanet/linux-x64/libepanetmsx.so")
+                libepanet = files('wntr.epanet').joinpath("libepanet/linux-x64/libepanet2.so")
+                libmsx = files('wntr.epanet').joinpath("libepanet/linux-x64/libepanetmsx.so")
 
             dylib_dir = os.environ.get('DYLD_FALLBACK_LIBRARY_PATH','')
             if dylib_dir != '':
                 if 'arm' in platform.platform().lower():
-                    dylib_dir = dylib_dir + ':' + files(epanet_toolkit).joinpath("libepanet/darwin-arm")
+                    dylib_dir = dylib_dir + ':' + files('wntr.epanet').joinpath("libepanet/darwin-arm")
                 else:
-                    dylib_dir = dylib_dir + ':' + files(epanet_toolkit).joinpath("libepanet/darwin-x64")
+                    dylib_dir = dylib_dir + ':' + files('wntr.epanet').joinpath("libepanet/darwin-x64")
                 os.environ['DYLD_FALLBACK_LIBRARY_PATH'] = dylib_dir
             if os.name in ["nt", "dos"]:
                 self.ENlib = ctypes.windll.LoadLibrary(libmsx)

--- a/wntr/epanet/msx/toolkit.py
+++ b/wntr/epanet/msx/toolkit.py
@@ -46,25 +46,25 @@ class MSXepanet(ENepanet):
 
         try:
             if os.name in ["nt", "dos"]:
-                libepanet = files('wntr.epanet').joinpath("libepanet/windows-x64/epanet2.dll")
-                libmsx = files('wntr.epanet').joinpath("libepanet/windows-x64/epanetmsx.dll")
+                libepanet = str(files('wntr.epanet').joinpath("libepanet/windows-x64/epanet2.dll"))
+                libmsx = str(files('wntr.epanet').joinpath("libepanet/windows-x64/epanetmsx.dll"))
             elif sys.platform in ["darwin"]:
                 if 'arm' in platform.platform().lower():
-                    libepanet = files('wntr.epanet').joinpath("libepanet/darwin-arm/libepanet2.dylib")
-                    libmsx = files('wntr.epanet').joinpath("libepanet/darwin-arm/libepanetmsx.dylib")
+                    libepanet = str(files('wntr.epanet').joinpath("libepanet/darwin-arm/libepanet2.dylib"))
+                    libmsx = str(files('wntr.epanet').joinpath("libepanet/darwin-arm/libepanetmsx.dylib"))
                 else:
-                    libepanet = files('wntr.epanet').joinpath("libepanet/darwin-x64/libepanet2.dylib")
-                    libmsx = files('wntr.epanet').joinpath("libepanet/darwin-x64/libepanetmsx.dylib")
+                    libepanet = str(files('wntr.epanet').joinpath("libepanet/darwin-x64/libepanet2.dylib"))
+                    libmsx = str(files('wntr.epanet').joinpath("libepanet/darwin-x64/libepanetmsx.dylib"))
             else:
-                libepanet = files('wntr.epanet').joinpath("libepanet/linux-x64/libepanet2.so")
-                libmsx = files('wntr.epanet').joinpath("libepanet/linux-x64/libepanetmsx.so")
+                libepanet = str(files('wntr.epanet').joinpath("libepanet/linux-x64/libepanet2.so"))
+                libmsx = str(files('wntr.epanet').joinpath("libepanet/linux-x64/libepanetmsx.so"))
 
             dylib_dir = os.environ.get('DYLD_FALLBACK_LIBRARY_PATH','')
             if dylib_dir != '':
                 if 'arm' in platform.platform().lower():
-                    dylib_dir = dylib_dir + ':' + files('wntr.epanet').joinpath("libepanet/darwin-arm")
+                    dylib_dir = dylib_dir + ':' + str(files('wntr.epanet').joinpath("libepanet/darwin-arm"))
                 else:
-                    dylib_dir = dylib_dir + ':' + files('wntr.epanet').joinpath("libepanet/darwin-x64")
+                    dylib_dir = dylib_dir + ':' + str(files('wntr.epanet').joinpath("libepanet/darwin-x64"))
                 os.environ['DYLD_FALLBACK_LIBRARY_PATH'] = dylib_dir
             if os.name in ["nt", "dos"]:
                 self.ENlib = ctypes.windll.LoadLibrary(libmsx)

--- a/wntr/epanet/msx/toolkit.py
+++ b/wntr/epanet/msx/toolkit.py
@@ -16,10 +16,7 @@ import platform
 import sys
 from typing import Union
 
-if sys.version_info[0:2] <= (3, 11):
-    from pkg_resources import resource_filename
-else:
-    from importlib.resources import files
+from importlib.resources import files
 
 from wntr.epanet.msx.enums import TkObjectType, TkSourceType
 
@@ -49,51 +46,27 @@ class MSXepanet(ENepanet):
         self.msxfile = msxfile
 
         try:
-            if sys.version_info[0:2] <= (3, 11):
-
-                if os.name in ["nt", "dos"]:
-                    libepanet = resource_filename(epanet_toolkit, "libepanet/windows-x64/epanet2.dll")
-                    libmsx = resource_filename(epanet_toolkit, "libepanet/windows-x64/epanetmsx.dll")
-                elif sys.platform in ["darwin"]:
-                    if 'arm' in platform.platform().lower():
-                        libepanet = resource_filename(epanet_toolkit, "libepanet/darwin-arm/libepanet2.dylib")
-                        libmsx = resource_filename(epanet_toolkit, "libepanet/darwin-arm/libepanetmsx.dylib")
-                    else:
-                        libepanet = resource_filename(epanet_toolkit, "libepanet/darwin-x64/libepanet2.dylib")
-                        libmsx = resource_filename(epanet_toolkit, "libepanet/darwin-x64/libepanetmsx.dylib")
+            if os.name in ["nt", "dos"]:
+                libepanet = files(epanet_toolkit).joinpath("libepanet/windows-x64/epanet2.dll")
+                libmsx = files(epanet_toolkit).joinpath("libepanet/windows-x64/epanetmsx.dll")
+            elif sys.platform in ["darwin"]:
+                if 'arm' in platform.platform().lower():
+                    libepanet = files(epanet_toolkit).joinpath("libepanet/darwin-arm/libepanet2.dylib")
+                    libmsx = files(epanet_toolkit).joinpath("libepanet/darwin-arm/libepanetmsx.dylib")
                 else:
-                    libepanet = resource_filename(epanet_toolkit, "libepanet/linux-x64/libepanet2.so")
-                    libmsx = resource_filename(epanet_toolkit, "libepanet/linux-x64/libepanetmsx.so")
-
-                dylib_dir = os.environ.get('DYLD_FALLBACK_LIBRARY_PATH','')
-                if dylib_dir != '':
-                    if 'arm' in platform.platform().lower():
-                        dylib_dir = dylib_dir + ':' + resource_filename(epanet_toolkit, "libepanet/darwin-arm")
-                    else:
-                        dylib_dir = dylib_dir + ':' + resource_filename(epanet_toolkit, "libepanet/darwin-x64")
-                    os.environ['DYLD_FALLBACK_LIBRARY_PATH'] = dylib_dir
+                    libepanet = files(epanet_toolkit).joinpath("libepanet/darwin-x64/libepanet2.dylib")
+                    libmsx = files(epanet_toolkit).joinpath("libepanet/darwin-x64/libepanetmsx.dylib")
             else:
-                if os.name in ["nt", "dos"]:
-                    libepanet = files(epanet_toolkit).joinpath("libepanet/windows-x64/epanet2.dll")
-                    libmsx = files(epanet_toolkit).joinpath("libepanet/windows-x64/epanetmsx.dll")
-                elif sys.platform in ["darwin"]:
-                    if 'arm' in platform.platform().lower():
-                        libepanet = files(epanet_toolkit).joinpath("libepanet/darwin-arm/libepanet2.dylib")
-                        libmsx = files(epanet_toolkit).joinpath("libepanet/darwin-arm/libepanetmsx.dylib")
-                    else:
-                        libepanet = files(epanet_toolkit).joinpath("libepanet/darwin-x64/libepanet2.dylib")
-                        libmsx = files(epanet_toolkit).joinpath("libepanet/darwin-x64/libepanetmsx.dylib")
-                else:
-                    libepanet = files(epanet_toolkit).joinpath("libepanet/linux-x64/libepanet2.so")
-                    libmsx = files(epanet_toolkit).joinpath("libepanet/linux-x64/libepanetmsx.so")
+                libepanet = files(epanet_toolkit).joinpath("libepanet/linux-x64/libepanet2.so")
+                libmsx = files(epanet_toolkit).joinpath("libepanet/linux-x64/libepanetmsx.so")
 
-                dylib_dir = os.environ.get('DYLD_FALLBACK_LIBRARY_PATH','')
-                if dylib_dir != '':
-                    if 'arm' in platform.platform().lower():
-                        dylib_dir = dylib_dir + ':' + files(epanet_toolkit).joinpath("libepanet/darwin-arm")
-                    else:
-                        dylib_dir = dylib_dir + ':' + files(epanet_toolkit).joinpath("libepanet/darwin-x64")
-                    os.environ['DYLD_FALLBACK_LIBRARY_PATH'] = dylib_dir
+            dylib_dir = os.environ.get('DYLD_FALLBACK_LIBRARY_PATH','')
+            if dylib_dir != '':
+                if 'arm' in platform.platform().lower():
+                    dylib_dir = dylib_dir + ':' + files(epanet_toolkit).joinpath("libepanet/darwin-arm")
+                else:
+                    dylib_dir = dylib_dir + ':' + files(epanet_toolkit).joinpath("libepanet/darwin-x64")
+                os.environ['DYLD_FALLBACK_LIBRARY_PATH'] = dylib_dir
             if os.name in ["nt", "dos"]:
                 self.ENlib = ctypes.windll.LoadLibrary(libmsx)
             else:

--- a/wntr/epanet/toolkit.py
+++ b/wntr/epanet/toolkit.py
@@ -111,7 +111,7 @@ class ENepanet:
                     raise NotImplementedError('ARM-based processors not supported for version 2.0 of EPANET. Please use version=2.2')
             else:
                 libname = libepanet
-            libname = files('wntr.epanet').joinpath(libname)
+            libname = str(files('wntr.epanet').joinpath(libname))
             if os.name in ["nt", "dos"]:
                 self.ENlib = ctypes.windll.LoadLibrary(libname)
             else:

--- a/wntr/epanet/toolkit.py
+++ b/wntr/epanet/toolkit.py
@@ -111,7 +111,7 @@ class ENepanet:
                     raise NotImplementedError('ARM-based processors not supported for version 2.0 of EPANET. Please use version=2.2')
             else:
                 libname = libepanet
-            libname = files(__name__).joinpath(libname)
+            libname = files('wntr.epanet').joinpath(libname)
             if os.name in ["nt", "dos"]:
                 self.ENlib = ctypes.windll.LoadLibrary(libname)
             else:

--- a/wntr/epanet/toolkit.py
+++ b/wntr/epanet/toolkit.py
@@ -10,10 +10,7 @@ import platform
 import sys
 from ctypes import byref
 
-if sys.version_info[0:2] <= (3, 11):
-    from pkg_resources import resource_filename
-else:
-    from importlib.resources import files
+from importlib.resources import files
 
 from .exceptions import EN_ERROR_CODES, EpanetException
 from .util import SizeLimits
@@ -108,30 +105,17 @@ class ENepanet:
         self.binfile = binfile
 
         try:
-            if sys.version_info[0:2] <= (3, 11):
-                if float(version) == 2.0:
-                    libname = libepanet.replace('epanet22.','epanet20.')
-                    if 'arm' in platform.platform():
-                        raise NotImplementedError('ARM-based processors not supported for version 2.0 of EPANET. Please use version=2.2')
-                else:
-                    libname = libepanet
-                libname = resource_filename(__name__, libname)
-                if os.name in ["nt", "dos"]:
-                    self.ENlib = ctypes.windll.LoadLibrary(libname)
-                else:
-                    self.ENlib = ctypes.cdll.LoadLibrary(libname)
+            if float(version) == 2.0:
+                libname = libepanet.replace('epanet22.','epanet20.')
+                if 'arm' in platform.platform():
+                    raise NotImplementedError('ARM-based processors not supported for version 2.0 of EPANET. Please use version=2.2')
             else:
-                if float(version) == 2.0:
-                    libname = libepanet.replace('epanet22.','epanet20.')
-                    if 'arm' in platform.platform():
-                        raise NotImplementedError('ARM-based processors not supported for version 2.0 of EPANET. Please use version=2.2')
-                else:
-                    libname = libepanet
-                libname = files(__name__).joinpath(libname)
-                if os.name in ["nt", "dos"]:
-                    self.ENlib = ctypes.windll.LoadLibrary(libname)
-                else:
-                    self.ENlib = ctypes.cdll.LoadLibrary(libname)
+                libname = libepanet
+            libname = files(__name__).joinpath(libname)
+            if os.name in ["nt", "dos"]:
+                self.ENlib = ctypes.windll.LoadLibrary(libname)
+            else:
+                self.ENlib = ctypes.cdll.LoadLibrary(libname)
         except:
             raise
         finally:

--- a/wntr/library/msx/_msxlibrary.py
+++ b/wntr/library/msx/_msxlibrary.py
@@ -18,13 +18,10 @@ from __future__ import annotations
 
 import json
 import logging
-import os, sys
+import os
 from typing import Any, ItemsView, Iterator, KeysView, List, Tuple, Union, ValuesView
 
-if sys.version_info[0:2] <= (3, 11):
-    from pkg_resources import resource_filename
-else:
-    from importlib.resources import files
+from importlib.resources import files
 
 from wntr.msx.base import ExpressionType, ReactionType, SpeciesType
 from wntr.msx.model import MsxModel
@@ -102,10 +99,7 @@ class MsxLibrary:
         self.__data = dict()
 
         if include_builtins:
-            if sys.version_info[0:2] <= (3, 11):
-                default_path = os.path.abspath(resource_filename(__name__, '.'))
-            else:
-                default_path = os.path.abspath(files('wntr.library.msx').joinpath('.'))
+            default_path = os.path.abspath(files('wntr.library.msx').joinpath('.'))
             if default_path not in self.__library_paths:
                 self.__library_paths.append(default_path)
 


### PR DESCRIPTION
## Summary
Remove the deprecated pkg_resources dependency (bundled with setuptools) and replace all usages with importlib.resources.files from the standard library. This required anchoring resource lookups to 'wntr.epanet' (a proper package) rather than 'wntr.epanet.toolkit' (a module), since files() requires a package on Python 3.10/3.11.

Also removes setuptools from runtime install_requires as it is a build tool, not a runtime tool.

Finally, bumps cibuildwheel from v2.21.0 to v3.1.4 to fix intermittent HTTP 429 errors when downloading virtualenv during wheel builds on GitHub Actions.

## Tests and documentation
n/a
 
## Acknowledgement
By contributing to this software project, I acknowledge that I have reviewed the [software quality assurance guidelines](https://usepa.github.io/WNTR/developers.html) and that my contributions are submitted under the [Revised BSD License](https://usepa.github.io/WNTR/license.html). 
