### PR TITLE
Fixes for expired deprecation of np.cross

### DIFF
--- a/wntr/morph/node.py
+++ b/wntr/morph/node.py
@@ -308,7 +308,8 @@ def _convert_with_map(wn, node_map, flag, return_copy):
     vect2_unit = vect2/np.linalg.norm(vect2)
     dotproduct = np.dot(vect1_unit, vect2_unit)
     if dotproduct < 1:
-        sign = np.sign(np.cross(vect1_unit, vect2_unit))
+        cross_z = vect1_unit[0]*vect2_unit[1] - vect1_unit[1]*vect2_unit[0]
+        sign = np.sign(cross_z)
         angle = np.arccos(dotproduct)*180/np.pi
         wn2 = rotate_node_coordinates(wn2, sign*angle)
         A[0] = np.array(wn2.get_node(node_names[0]).coordinates)


### PR DESCRIPTION
## Summary
- [x] Summarize changes, including issues that are resolved by this pull request

As of numpy 2.0 (https://github.com/numpy/numpy/pull/24818), the use of np.cross with 2D (rather than 3D) parameters has been deprecated and in the latest versions of numpy this usage now raises exception.

This deprecated usage was implemented in node.py for coordinate conversion. To prevent the exception, it has been replaced by the equivalent calculation written as an ordinary python expression.

## Tests and documentation
- [ ] Describe tests and documentation for new features
 
## AI Disclosure
If you submit code generated using AI tools:
- [ ] Disclose the AI tools that were used (e.g., GitHub Copilot, ChatGPT)
- [ ] Describe the use of AI (e.g., generate concept/idea, code generation, code refactoring, documentation generation, code test generation)

## Acknowledgement
By contributing to WNTR, I acknowledge that I have reviewed the software quality assurance guidelines and agree to the following terms and conditions for my contribution:
1. I agree that my contributions are submitted under the Revised BSD License.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
3. If code was generated using AI tools, I have disclosed the use of AI and reviewed all code for quality assurance, correctness, security, and licensing.
