### PR TITLE
Fix evaluation of TimeOfDayCondition

### DIFF
--- a/wntr/network/controls.py
+++ b/wntr/network/controls.py
@@ -415,8 +415,6 @@ class TimeOfDayCondition(ControlCondition):
         the time specified.
     first_day : float, default=0
         Start rule on day `first_day`, with the first day of simulation as day 0
-
-    TODO:  WE ARE NOT TESTING THIS!!!!
     """
     def __init__(self, model, relation, threshold, repeat=True, first_day=0):
         self._model = model
@@ -491,29 +489,55 @@ class TimeOfDayCondition(ControlCondition):
         cur_time = self._model._shifted_time
         prev_time = self._model._prev_shifted_time
         day = np.floor(cur_time/86400)
+        
         if day < self._first_day:
             self._backtrack = None
             return False
+        
+        threshold = self._threshold
+        
         if self._repeat:
-            cur_time = int(cur_time - self._threshold) % 86400
-            prev_time = int(prev_time - self._threshold) % 86400
+            cur_time = cur_time % 86400
+            prev_time = prev_time % 86400
+            wrapped = cur_time < prev_time
         else:
             cur_time = cur_time - self._first_day * 86400.
             prev_time = prev_time - self._first_day * 86400.
-        if self._relation is Comparison.eq and (prev_time < self._threshold and self._threshold <= cur_time):
-            self._backtrack = int(cur_time - self._threshold)
-            return True
-        elif self._relation is Comparison.gt and cur_time >= self._threshold and prev_time < self._threshold:
-            self._backtrack = int(cur_time - self._threshold)
-            return True
-        elif self._relation is Comparison.gt and cur_time >= self._threshold and prev_time >= self._threshold:
+            wrapped = False
+        
+        if self._relation is Comparison.eq:
+            if not wrapped:
+                fired = prev_time < threshold <= cur_time
+            else:
+                fired = prev_time < threshold or threshold <= cur_time
+            if fired:
+                self._backtrack = int((cur_time - threshold) % 86400)
+                return True
             self._backtrack = 0
-            return True
-        elif self._relation is Comparison.lt and cur_time >= self._threshold and prev_time < self._threshold:
-            self._backtrack = int(cur_time - self._threshold)
             return False
-        elif self._relation is Comparison.lt and cur_time >= self._threshold and prev_time >= self._threshold:
+        
+        elif self._relation in (Comparison.gt, Comparison.ge):
+            fired_now = cur_time >= threshold
+            fired_prev = (not wrapped) and prev_time >= threshold
+            if fired_now and not fired_prev:
+                self._backtrack = int((cur_time - threshold) % 86400)
+                return True
+            elif fired_now and fired_prev:
+                self._backtrack = 0
+                return True
             self._backtrack = 0
+            return False
+        
+        elif self._relation in (Comparison.lt, Comparison.le):
+            fired_now = cur_time < threshold
+            if fired_now:
+                self._backtrack = 0
+                return True
+            crossed_prev = (not wrapped) and prev_time >= threshold
+            if not crossed_prev:
+                self._backtrack = int(cur_time - threshold)
+            else:
+                self._backtrack = 0
             return False
         else:
             self._backtrack = 0

--- a/wntr/tests/test_network_controls.py
+++ b/wntr/tests/test_network_controls.py
@@ -825,5 +825,98 @@ class TestControlParsing(unittest.TestCase):
         self.assertEqual(control._condition._relation, self.wntr.network.controls.Comparison.lt)
 
 
+class TestTimeOfDayCondition(unittest.TestCase):
+    def _step(self, wn, condition, prev_time, cur_time):
+        """Used to mock the forward stepping of a simulation """
+        wn._prev_sim_time = prev_time
+        wn.sim_time = cur_time
+        return condition.evaluate()
+
+    def test_eq_fires_once_per_day_at_threshold(self):
+        wn = wntr.network.WaterNetworkModel()
+        threshold = 3600.0  # 1 AM
+        condition = wntr.network.controls.TimeOfDayCondition(wn, None, threshold)
+
+        self.assertFalse(self._step(wn, condition, 0, 1800))
+        self.assertTrue(self._step(wn, condition, 1800, 5400))
+        # only fires once per day, even if re-evaluated at the same step boundary
+        self.assertFalse(self._step(wn, condition, 5400, 9000))
+        # fires again on day 2 at the same time of day
+        self.assertFalse(self._step(wn, condition, 86400 + 1800, 86400 + 1800))
+        self.assertTrue(self._step(wn, condition, 86400 + 1800, 86400 + 5400))
+
+    def test_eq_fires_across_midnight_wrap(self):
+        wn = wntr.network.WaterNetworkModel()
+        threshold = 23 * 3600.0  # 11 PM
+        condition = wntr.network.controls.TimeOfDayCondition(wn, None, threshold)
+
+        prev_time = 22 * 3600.0
+        cur_time = 25 * 3600.0  # 1 AM the next day
+        self.assertTrue(self._step(wn, condition, prev_time, cur_time))
+
+    def test_gt_after_threshold_until_midnight(self):
+        wn = wntr.network.WaterNetworkModel()
+        threshold = 15 * 3600.0  # 3 PM
+        condition = wntr.network.controls.TimeOfDayCondition(wn, 'after', threshold)
+
+        self.assertFalse(self._step(wn, condition, 12 * 3600.0, 14 * 3600.0))
+        self.assertTrue(self._step(wn, condition, 14 * 3600.0, 16 * 3600.0))
+        self.assertTrue(self._step(wn, condition, 16 * 3600.0, 18 * 3600.0))
+        # resets at midnight
+        self.assertFalse(self._step(wn, condition, 23 * 3600.0, 25 * 3600.0))
+
+    def test_lt_before_threshold_resets_at_midnight(self):
+        wn = wntr.network.WaterNetworkModel()
+        threshold = 6 * 3600.0  # 6 AM
+        condition = wntr.network.controls.TimeOfDayCondition(wn, 'before', threshold)
+
+        self.assertTrue(self._step(wn, condition, 0, 2 * 3600.0))
+        self.assertFalse(self._step(wn, condition, 5 * 3600.0, 7 * 3600.0))
+        self.assertFalse(self._step(wn, condition, 7 * 3600.0, 9 * 3600.0))
+        # back to "before threshold" after the midnight reset
+        self.assertTrue(self._step(wn, condition, 23 * 3600.0, 25 * 3600.0))
+
+    def test_ge_le_do_not_silently_never_fire(self):
+        wn = wntr.network.WaterNetworkModel()
+        ge_condition = wntr.network.controls.TimeOfDayCondition(wn, '>=', 12 * 3600.0)
+        le_condition = wntr.network.controls.TimeOfDayCondition(wn, '<=', 12 * 3600.0)
+
+        self.assertTrue(self._step(wn, ge_condition, 11 * 3600.0, 13 * 3600.0))
+        self.assertTrue(self._step(wn, le_condition, 0, 2 * 3600.0))
+
+
+class TestClockTimeControlAgainstEpanet(unittest.TestCase):
+
+    def _build_model(self):
+        wn = wntr.network.WaterNetworkModel("Net3")
+        for name in list(wn.control_name_list):
+            control = wn.get_control(name)
+            if isinstance(control._condition, wntr.network.controls.SimTimeCondition):
+                wn.remove_control(name)
+
+        pump = wn.get_link("10")
+        open_condition = wntr.network.controls.TimeOfDayCondition(wn, None, "1:00:00 AM")
+        open_action = wntr.network.ControlAction(pump, "status", wntr.network.LinkStatus.Open)
+        wn.add_control("pump_10_open", wntr.network.Control(open_condition, open_action))
+
+        close_condition = wntr.network.controls.TimeOfDayCondition(wn, None, "3:00:00 PM")
+        close_action = wntr.network.ControlAction(pump, "status", wntr.network.LinkStatus.Closed)
+        wn.add_control("pump_10_close", wntr.network.Control(close_condition, close_action))
+
+        wn.options.time.duration = 24 * 3600
+        wn.options.time.report_timestep = 3600
+        return wn
+
+    def test_repeating_clocktime_schedule_matches_epanet(self):
+        ep_status = wntr.sim.EpanetSimulator(self._build_model()).run_sim().link["status"]["10"]
+        wntr_status = wntr.sim.WNTRSimulator(self._build_model()).run_sim().link["status"]["10"]
+
+        for t in wntr_status.index:
+            self.assertEqual(
+                int(ep_status.loc[t]), int(wntr_status.loc[t]),
+                msg="pump 10 status differs from EPANET at sim_time={}".format(t),
+            )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Provide a summary of the proposed changes, describe tests and documentation, and review the acknowledgement below. 
 
## Summary
- [x] Summarize changes, including issues that are resolved by this pull request

This PR fixes TimeOfDayCondition.evaluate(), which had three bugs (demonstrated by the EPANET/WNTR mismatch in #559):

- Wrong reference frame. For repeating conditions, time was shifted by the threshold ((time - threshold) % 86400) and then compared against the threshold again which mixed "seconds since threshold" with "absolute seconds-of-day."
- lt/"before" never fired: every branch only covered crossing out of the window; there was no branch for actually being inside it.
- ge/le were unhandled entirely, silently falling through to False.

Fix: keep cur_time/prev_time in one consistent time-of-day frame (time % 86400) and compare each relation directly against the threshold. A `wrapped` flag prevents a step spanning is used to handle _backtrack logic.

## Tests and documentation
- [x] Describe tests and documentation for new features
 
## AI Disclosure
If you submit code generated using AI tools:
- [x] Disclose the AI tools that were used (e.g., GitHub Copilot, ChatGPT)
- [x] Describe the use of AI (e.g., generate concept/idea, code generation, code refactoring, documentation generation, code test generation)

## Acknowledgement
By contributing to WNTR, I acknowledge that I have reviewed the software quality assurance guidelines and agree to the following terms and conditions for my contribution:
1. I agree that my contributions are submitted under the Revised BSD License.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
3. If code was generated using AI tools, I have disclosed the use of AI and reviewed all code for quality assurance, correctness, security, and licensing.
