### PR TITLE
Add clarification on pump speed to limitations documentation

### DIFF
--- a/documentation/framework.rst
+++ b/documentation/framework.rst
@@ -146,7 +146,8 @@ Of the EPANET model options that directly apply to hydraulic simulations, **the 
 * [EMITTERS] section
 * D-W and C-M headloss options in the [OPTIONS] section (H-W option is used)
 * Accuracy, unbalanced, and emitter exponent from the [OPTIONS] section
-* Pump speed in the [PUMPS] section
+* Pump speed (other than the default value of 1.0) in the [PUMPS] section,
+  including pump speeds set using controls/rules or speed patterns
 * Report start and statistics in the [TIMES] section
 * PBV and GPV values in the [VALVES] section
 
@@ -162,12 +163,15 @@ Known discrepancies between the WNTRSimulator and EpanetSimulator are listed bel
   minimum elevation. This can result in incorrect system pressures.
   See issues at the following sites: https://github.com/USEPA/WNTR/issues/210 and https://github.com/OpenWaterAnalytics/EPANET/issues/623.
   The EPANET dll in WNTR will be updated when an EPANET release is available.
-* **Pump controls and patterns**: Pumps have speed settings which are adjustable 
-  by controls and/or patterns. With the EpanetSimulator, 
-  controls and patterns adjust the actual speed. With the WNTRSimulator, pumps have a 'base speed' 
-  (similar to junction demand and reservoir head), controls adjust the base speed, and speed patterns are 
-  a multiplier on the base speed. Results from the two simulators can match by scaling speed patterns 
-  and using controls appropriately.
+* **Pump controls and patterns**: Pumps have speed settings which are adjustable
+  by controls and/or patterns. With the EpanetSimulator,
+  controls and patterns adjust the actual speed. With the WNTRSimulator, pumps have a 'base speed'
+  (similar to junction demand and reservoir head) and speed patterns are
+  a multiplier on the base speed; however, the WNTRSimulator currently only supports a pump speed
+  (``base_speed`` multiplied by the speed pattern, if used) of 1.0. Setting the pump speed to a value
+  other than 1.0 using a control, rule, or speed pattern will raise a ``NotImplementedError`` when
+  running the WNTRSimulator. See :ref:`limitations` for more information. This functionality is supported
+  by the EpanetSimulator.
 * **Leak models**: Leak models are only available using the WNTRSimulator. Emitters can be used to model leaks in EPANET.
 * **Multi-point head pump curves**: When using the EpanetSimulator, multi-point 
   head pump curves are created by connecting the points with straight-line segments.  


### PR DESCRIPTION
## Summary
- [x] Summarize changes, including issues that are resolved by this pull request

This PR clarifies a known WNTR simulator limitation in the documentation. While the EPANET simulator allows for variable pump speeds, the WNTR simulator does not currently have this capability.

Addresses #545 

## Tests and documentation
- [x] Describe tests and documentation for new features

Clarification added to `framework.rst`.
 
## AI Disclosure
If you submit code generated using AI tools:
- [x] Disclose the AI tools that were used (e.g., GitHub Copilot, ChatGPT)
- [x] Describe the use of AI (e.g., generate concept/idea, code generation, code refactoring, documentation generation, code test generation)

## Acknowledgement
By contributing to WNTR, I acknowledge that I have reviewed the software quality assurance guidelines and agree to the following terms and conditions for my contribution:
1. I agree that my contributions are submitted under the Revised BSD License.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
3. If code was generated using AI tools, I have disclosed the use of AI and reviewed all code for quality assurance, correctness, security, and licensing.
