### PR TITLE
Geopandas backend for valve layer

### DIFF
--- a/wntr/graphics/layer.py
+++ b/wntr/graphics/layer.py
@@ -5,66 +5,101 @@ water network data layers.
 import logging
 import networkx as nx
 import numpy as np
+import pandas as pd
 import matplotlib.pyplot as plt
+import matplotlib as mpl
 
 logger = logging.getLogger(__name__)
 
+try:
+    import geopandas as gpd_module
+    from shapely.geometry import Point
+except Exception:
+    gpd_module = None
+
+
 def plot_valve_layer(wn, valve_layer, valve_attribute=None, title=None,
-               valve_size=15, valve_range=[None,None], valve_cmap=None, add_colorbar=True, 
-               colorbar_label=None, include_network=True, ax=None, filename=None):
+               valve_size=15, valve_range=[None,None], valve_cmap=None, add_colorbar=True,
+               colorbar_label=None, include_network=True, ax=None, filename=None, backend='nx'):
     """
     Plot valve layer
-    
+
     Parameters
     ----------
     wn: wntr WaterNetworkModel
         A WaterNetworkModel object
-    
+
     valve_layer: pd.Dataframe, optional
-        Valve layer, defined by node and link pairs (for example, valve 0 is 
+        Valve layer, defined by node and link pairs (for example, valve 0 is
         on link A and protects node B). The valve_layer DataFrame is indexed by
         valve number, with columns named 'node' and 'link'.
-    
+
     valve_attribute: pd.Series, optional
         Attribute for each valve
-        
+
     title: str, optional
-        Plot title 
+        Plot title
 
     valve_size: int, optional
-        Node size 
-    
+        Node size
+
     valve_range: list, optional
         Value range used to scale colormap ([None,None] indicates autoscale)
-        
+
     valve_cmap: matplotlib.pyplot.cm colormap or named color, optional
-        Valve colormap 
+        Valve colormap
 
     add_colorbar: bool, optional
         Add colorbar
-    
+
     colorbar_label: str, optional
         Node colorbar label
-    
-    include_network: bool, options
-        Include a plot of the water network 
-        
+
+    include_network: bool, optional
+        Include a plot of the water network
+
     ax: matplotlib axes object, optional
-        Axes for plotting (None indicates that a new figure with a single 
+        Axes for plotting (None indicates that a new figure with a single
         axes will be used)
-        
+
     filename : str, optional
         Filename used to save the figure
-        
+
+    backend: str, optional
+        Backend used for plotting:
+        'nx' for networkx (default)
+        'gpd' for geopandas
+
     Returns
     -------
-    ax : matplotlib axes object  
+    ax : matplotlib axes object
+    """
+    if backend == 'nx':
+        ax = _plot_valve_layer_nx(wn, valve_layer, valve_attribute=valve_attribute, title=title,
+               valve_size=valve_size, valve_range=valve_range, valve_cmap=valve_cmap,
+               add_colorbar=add_colorbar, colorbar_label=colorbar_label,
+               include_network=include_network, ax=ax, filename=filename)
+    elif backend == 'gpd':
+        ax = _plot_valve_layer_gpd(wn, valve_layer, valve_attribute=valve_attribute, title=title,
+               valve_size=valve_size, valve_range=valve_range, valve_cmap=valve_cmap,
+               add_colorbar=add_colorbar, colorbar_label=colorbar_label,
+               include_network=include_network, ax=ax, filename=filename)
+    else:
+        raise Exception(f"Backend choice {backend} unrecognized. Please use 'nx' for networkx or 'gpd' for geopandas.")
+    return ax
+
+
+def _plot_valve_layer_nx(wn, valve_layer, valve_attribute=None, title=None,
+               valve_size=15, valve_range=[None,None], valve_cmap=None, add_colorbar=True,
+               colorbar_label=None, include_network=True, ax=None, filename=None):
+    """
+    Plot valve layer using the networkx backend.
     """
 
     if ax is None: # create a new figure
         plt.figure(facecolor='w', edgecolor='k')
         ax = plt.gca()
-        
+
     # Graph, undirected
     G = wn.to_graph().to_undirected()
 
@@ -75,12 +110,12 @@ def plot_valve_layer(wn, valve_layer, valve_attribute=None, title=None,
 
     if title is not None:
         ax.set_title(title)
-    
+
     if include_network:
         nx.draw_networkx_edges(G, pos, edge_color='grey', width=0.5, ax=ax)
-        
+
     ax.axis('off')
-    
+
     valve_coordinates = []
     for valve_name, (pipe_name, node_name) in valve_layer.iterrows():
         pipe = wn.get_link(pipe_name)
@@ -98,20 +133,97 @@ def plot_valve_layer(wn, valve_layer, valve_attribute=None, title=None,
         y0 = start_node.coordinates[1]
         dy = end_node.coordinates[1] - y0
         valve_coordinates.append((x0 + dx * 0.1, y0 + dy * 0.1))
-    
+
     valve_coordinates = np.array(valve_coordinates)
-    
-    if valve_attribute is not None: 
-        sc = ax.scatter(valve_coordinates[:,0], valve_coordinates[:,1], s=valve_size, c=valve_attribute, marker='v', cmap=valve_cmap)  
+
+    if valve_attribute is not None:
+        sc = ax.scatter(valve_coordinates[:,0], valve_coordinates[:,1], s=valve_size, c=valve_attribute, marker='v', cmap=valve_cmap)
     else:
-        sc = ax.scatter(valve_coordinates[:,0], valve_coordinates[:,1], valve_size, 'k', 'v')   
- 
-    if add_colorbar:
+        sc = ax.scatter(valve_coordinates[:,0], valve_coordinates[:,1], valve_size, 'k', 'v')
+
+    if add_colorbar and valve_attribute is not None:
         clb = plt.colorbar(sc, shrink=0.5, pad=0.05, ax=ax)
         clb.ax.set_title(colorbar_label, fontsize=10)
         clb.mappable.set_clim(valve_range[0],valve_range[1])
-        
+
     if filename:
         plt.savefig(filename)
-        
+
+    return ax
+
+
+def _plot_valve_layer_gpd(wn, valve_layer, valve_attribute=None, title=None,
+               valve_size=15, valve_range=[None,None], valve_cmap=None, add_colorbar=True,
+               colorbar_label=None, include_network=True, ax=None, filename=None):
+    """
+    Plot valve layer using the geopandas backend. Valve markers are drawn at
+    zorder=6, above all elements rendered by _plot_network_gpd (max zorder=5).
+    """
+
+    if gpd_module is None:
+        raise ImportError('geopandas and shapely are required for the gpd backend')
+
+    if ax is None:
+        plt.figure(facecolor='w', edgecolor='k')
+        ax = plt.gca()
+
+    if title is not None:
+        ax.set_title(title)
+
+    wn_gis = wn.to_gis()
+    link_gdf = pd.concat((wn_gis.pipes, wn_gis.pumps, wn_gis.valves))
+
+    if include_network:
+        link_gdf.plot(ax=ax, aspect="equal", color='grey', linewidth=0.5, zorder=1)
+
+    valve_points = []
+    valve_indices = []
+    for valve_name, (pipe_name, node_name) in valve_layer.iterrows():
+        pipe = wn.get_link(pipe_name)
+        if pipe_name not in link_gdf.index:
+            print("Not valid")
+            continue
+        geom = link_gdf.loc[pipe_name, "geometry"]
+        if node_name == pipe.start_node_name:
+            valve_points.append(geom.interpolate(0.1, normalized=True))
+        elif node_name == pipe.end_node_name:
+            valve_points.append(geom.interpolate(0.9, normalized=True))
+        else:
+            print("Not valid")
+            continue
+        valve_indices.append(valve_name)
+
+    valve_gdf = gpd_module.GeoDataFrame(index=valve_indices, geometry=valve_points)
+
+    valve_kwds = {"marker": "v", "markersize": valve_size, "zorder": 6, "aspect": "equal", "legend": False}
+
+    if valve_attribute is not None:
+        valve_gdf["_attribute"] = pd.Series(valve_attribute).reindex(valve_indices)
+        valve_kwds["column"] = "_attribute"
+        if valve_cmap is not None:
+            valve_kwds["cmap"] = valve_cmap
+        if valve_range[0] is not None:
+            valve_kwds["vmin"] = valve_range[0]
+        if valve_range[1] is not None:
+            valve_kwds["vmax"] = valve_range[1]
+    else:
+        valve_kwds["color"] = "k"
+
+    valve_gdf.plot(ax=ax, **valve_kwds)
+
+    if add_colorbar and valve_attribute is not None:
+        attr_values = valve_gdf["_attribute"]
+        vmin = valve_range[0] if valve_range[0] is not None else attr_values.min()
+        vmax = valve_range[1] if valve_range[1] is not None else attr_values.max()
+        cmap = valve_cmap if valve_cmap is not None else plt.get_cmap('Spectral_r')
+        sm = mpl.cm.ScalarMappable(cmap=cmap)
+        sm.set_clim(vmin, vmax)
+        clb = ax.figure.colorbar(sm, ax=ax, shrink=0.5, pad=0.05)
+        clb.ax.set_title(colorbar_label, fontsize=10)
+
+    ax.axis('off')
+
+    if filename:
+        plt.savefig(filename)
+
     return ax

--- a/wntr/graphics/layer.py
+++ b/wntr/graphics/layer.py
@@ -139,7 +139,7 @@ def _plot_valve_layer_nx(wn, valve_layer, valve_attribute=None, title=None,
     if valve_attribute is not None:
         sc = ax.scatter(valve_coordinates[:,0], valve_coordinates[:,1], s=valve_size, c=valve_attribute, marker='v', cmap=valve_cmap)
     else:
-        sc = ax.scatter(valve_coordinates[:,0], valve_coordinates[:,1], valve_size, 'k', 'v')
+        sc = ax.scatter(valve_coordinates[:,0], valve_coordinates[:,1], s=valve_size, c='k', marker='v')
 
     if add_colorbar and valve_attribute is not None:
         clb = plt.colorbar(sc, shrink=0.5, pad=0.05, ax=ax)

--- a/wntr/tests/test_graphics.py
+++ b/wntr/tests/test_graphics.py
@@ -355,35 +355,18 @@ class TestGraphics(unittest.TestCase):
         )
         self.assertEqual(cmp.N, 3)
         self.assertEqual(cmp.name, "custom")
-        
-        
-
-
-class TestValveLayerGraphics(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        inp_file = join(ex_datadir, "Net3.inp")
-        cls.wn = wntr.network.WaterNetworkModel(inp_file)
-        cls.valve_layer = wntr.network.generate_valve_layer(
-            cls.wn, placement_type="strategic", n=2, seed=42
-        )
-        cls.valve_attribute = pd.Series(
-            np.random.default_rng(42).random(len(cls.valve_layer)),
-            index=cls.valve_layer.index,
-        )
 
     def test_plot_valve_layer_nx(self):
         filename = abspath(join(testdir, "plot_valve_layer_nx.png"))
         if isfile(filename):
             os.remove(filename)
 
+        wn = wntr.network.WaterNetworkModel("Net3")
+        valve_layer = wntr.network.generate_valve_layer(wn, "strategic", 2, 42)
+
         fig, axes = plt.subplots(1, 2)
-        wntr.graphics.plot_valve_layer(
-            self.wn, self.valve_layer, backend="nx", include_network=False, ax=axes[0]
-        )
-        wntr.graphics.plot_valve_layer(
-            self.wn, self.valve_layer, backend="nx", include_network=True, ax=axes[1]
-        )
+        wntr.graphics.plot_valve_layer(wn, valve_layer, backend="nx", include_network=False, ax=axes[0])
+        wntr.graphics.plot_valve_layer(wn, valve_layer, backend="nx", include_network=True, ax=axes[1])
         plt.savefig(filename, format="png")
         plt.close()
 
@@ -394,13 +377,12 @@ class TestValveLayerGraphics(unittest.TestCase):
         if isfile(filename):
             os.remove(filename)
 
+        wn = wntr.network.WaterNetworkModel("Net3")
+        valve_layer = wntr.network.generate_valve_layer(wn, "strategic", 2, 42)
+
         fig, axes = plt.subplots(1, 2)
-        wntr.graphics.plot_valve_layer(
-            self.wn, self.valve_layer, backend="gpd", include_network=False, ax=axes[0]
-        )
-        wntr.graphics.plot_valve_layer(
-            self.wn, self.valve_layer, backend="gpd", include_network=True, ax=axes[1]
-        )
+        wntr.graphics.plot_valve_layer(wn, valve_layer, backend="gpd", include_network=False, ax=axes[0])
+        wntr.graphics.plot_valve_layer(wn, valve_layer, backend="gpd", include_network=True, ax=axes[1])
         plt.savefig(filename, format="png")
         plt.close()
 
@@ -411,13 +393,19 @@ class TestValveLayerGraphics(unittest.TestCase):
         if isfile(filename):
             os.remove(filename)
 
+        wn = wntr.network.WaterNetworkModel("Net3")
+        valve_layer = wntr.network.generate_valve_layer(wn, "strategic", 2, 42)
+        valve_attribute = pd.Series(
+            np.random.default_rng(42).random(len(valve_layer)), index=valve_layer.index
+        )
+
         fig, axes = plt.subplots(1, 2)
         wntr.graphics.plot_valve_layer(
-            self.wn, self.valve_layer, valve_attribute=self.valve_attribute,
+            wn, valve_layer, valve_attribute=valve_attribute,
             colorbar_label="Test", backend="nx", ax=axes[0]
         )
         wntr.graphics.plot_valve_layer(
-            self.wn, self.valve_layer, valve_attribute=self.valve_attribute,
+            wn, valve_layer, valve_attribute=valve_attribute,
             colorbar_label="Test", backend="gpd", ax=axes[1]
         )
         plt.savefig(filename, format="png")
@@ -426,10 +414,11 @@ class TestValveLayerGraphics(unittest.TestCase):
         self.assertTrue(isfile(filename))
 
     def test_plot_valve_layer_invalid_backend(self):
+        wn = wntr.network.WaterNetworkModel("Net3")
+        valve_layer = wntr.network.generate_valve_layer(wn, "strategic", 2, 42)
+
         with self.assertRaises(Exception):
-            wntr.graphics.plot_valve_layer(
-                self.wn, self.valve_layer, backend="invalid"
-            )
+            wntr.graphics.plot_valve_layer(wn, valve_layer, backend="invalid")
 
 
 if __name__ == "__main__":

--- a/wntr/tests/test_graphics.py
+++ b/wntr/tests/test_graphics.py
@@ -359,5 +359,78 @@ class TestGraphics(unittest.TestCase):
         
 
 
+class TestValveLayerGraphics(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        inp_file = join(ex_datadir, "Net3.inp")
+        cls.wn = wntr.network.WaterNetworkModel(inp_file)
+        cls.valve_layer = wntr.network.generate_valve_layer(
+            cls.wn, placement_type="strategic", n=2, seed=42
+        )
+        cls.valve_attribute = pd.Series(
+            np.random.default_rng(42).random(len(cls.valve_layer)),
+            index=cls.valve_layer.index,
+        )
+
+    def test_plot_valve_layer_nx(self):
+        filename = abspath(join(testdir, "plot_valve_layer_nx.png"))
+        if isfile(filename):
+            os.remove(filename)
+
+        fig, axes = plt.subplots(1, 2)
+        wntr.graphics.plot_valve_layer(
+            self.wn, self.valve_layer, backend="nx", include_network=False, ax=axes[0]
+        )
+        wntr.graphics.plot_valve_layer(
+            self.wn, self.valve_layer, backend="nx", include_network=True, ax=axes[1]
+        )
+        plt.savefig(filename, format="png")
+        plt.close()
+
+        self.assertTrue(isfile(filename))
+
+    def test_plot_valve_layer_gpd(self):
+        filename = abspath(join(testdir, "plot_valve_layer_gpd.png"))
+        if isfile(filename):
+            os.remove(filename)
+
+        fig, axes = plt.subplots(1, 2)
+        wntr.graphics.plot_valve_layer(
+            self.wn, self.valve_layer, backend="gpd", include_network=False, ax=axes[0]
+        )
+        wntr.graphics.plot_valve_layer(
+            self.wn, self.valve_layer, backend="gpd", include_network=True, ax=axes[1]
+        )
+        plt.savefig(filename, format="png")
+        plt.close()
+
+        self.assertTrue(isfile(filename))
+
+    def test_plot_valve_layer_with_attribute(self):
+        filename = abspath(join(testdir, "plot_valve_layer_attribute.png"))
+        if isfile(filename):
+            os.remove(filename)
+
+        fig, axes = plt.subplots(1, 2)
+        wntr.graphics.plot_valve_layer(
+            self.wn, self.valve_layer, valve_attribute=self.valve_attribute,
+            colorbar_label="Test", backend="nx", ax=axes[0]
+        )
+        wntr.graphics.plot_valve_layer(
+            self.wn, self.valve_layer, valve_attribute=self.valve_attribute,
+            colorbar_label="Test", backend="gpd", ax=axes[1]
+        )
+        plt.savefig(filename, format="png")
+        plt.close()
+
+        self.assertTrue(isfile(filename))
+
+    def test_plot_valve_layer_invalid_backend(self):
+        with self.assertRaises(Exception):
+            wntr.graphics.plot_valve_layer(
+                self.wn, self.valve_layer, backend="invalid"
+            )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

<!-- Summarize your changes, including any issues resolved by this pull request -->
This PR continues work started in #451 by adding a GeoPandas backend plotting option for `plot_valve_layer`. This modernizes another important plotting function while also handling several issues with the function:
- When using the nx version of `plot_valve_layer` with the 'gpd' backend for `plot_network` the valves appear underneath the network (this is caused by a zorder issue).
-  The nx valve layer plotting does not take into account vertices when choosing valve coordinates, which can cause mismatches when using the 'gpd' `plot_network`.
- The nx valve layer plotting would cause some unwanted artifacts in some cases.

Comparison plot:
<img width="951" height="792" alt="image" src="https://github.com/user-attachments/assets/e8bf8348-5513-4e81-a106-f7ab773fdf4a" />


## Tests and Documentation

<!-- Describe the tests and documentation added or updated for new features -->
Added tests for previously untested `plot_valve_layer` function.

## AI Disclosure

<!-- If you did not use AI tools, mark the checkbox below and skip the rest of this section -->
- [x] No AI tools were used in this contribution

<!-- If you used AI tools, complete the following instead -->
- [ ] I used AI tools in this contribution. <!-- Disclose the AI tools that were used (e.g., GitHub Copilot, ChatGPT) and the use of AI (e.g., generate concept/idea, code generation, code refactoring, documentation generation, code test generation). -->

## Acknowledgement

By contributing to WNTR, I acknowledge that I have reviewed the [software quality assurance guidelines](https://usepa.github.io/WNTR/developers.html) and agree to the following terms and conditions for my contribution:

1. I agree that my contributions are submitted under the Revised BSD License.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
3. If code was generated using AI tools, I have disclosed the use of AI and reviewed all code for quality assurance, correctness, security, and licensing.

- [x] I have read and agree to the above acknowledgement

<img width="951" height="792" alt="image" src="https://github.com/user-attachments/assets/bba47943-ba52-42db-b18f-0dc65a0fb599" />


## Tests and Documentation

<!-- Describe the tests and documentation added or updated for new features -->
Added tests for previously untested `plot_valve_layer` function.

## AI Disclosure

<!-- If you did not use AI tools, mark the checkbox below and skip the rest of this section -->
- [x] No AI tools were used in this contribution

<!-- If you used AI tools, complete the following instead -->
- [ ] I used AI tools in this contribution. <!-- Disclose the AI tools that were used (e.g., GitHub Copilot, ChatGPT) and the use of AI (e.g., generate concept/idea, code generation, code refactoring, documentation generation, code test generation). -->

## Acknowledgement

By contributing to WNTR, I acknowledge that I have reviewed the [software quality assurance guidelines](https://usepa.github.io/WNTR/developers.html) and agree to the following terms and conditions for my contribution:

1. I agree that my contributions are submitted under the Revised BSD License.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
3. If code was generated using AI tools, I have disclosed the use of AI and reviewed all code for quality assurance, correctness, security, and licensing.

- [x] I have read and agree to the above acknowledgement
