### PR TITLE
Fix partial link attribute plotting for 'gpd' backend

### DIFF
--- a/wntr/graphics/network.py
+++ b/wntr/graphics/network.py
@@ -595,6 +595,7 @@ def _plot_network_gpd(
     link_cbar = add_colorbar
     if link_attribute is not None:
         link_gdf["_attribute"] = pd.Series(_format_link_attribute(link_attribute, wn))
+        link_gdf = link_gdf[link_gdf["_attribute"].notna()]
         link_kwds["column"] = "_attribute"
         
         # handle cbar/cmap
@@ -634,8 +635,6 @@ def _plot_network_gpd(
     link_cbar_kwds["label"] = link_colorbar_label
     link_cbar_kwds["alpha"] = link_alpha
     
-    missing_link_kwds={"color": "black"}
-
     # plot nodes - each type is plotted separately to allow for different marker types
     node_gdf[node_gdf.node_type == "Junction"].plot(
         ax=ax, aspect=aspect, zorder=3, legend=False, label="Junction", **node_kwds)
@@ -661,7 +660,7 @@ def _plot_network_gpd(
     
     # main plot
     link_gdf.plot(
-        ax=ax, aspect=aspect, zorder=2, legend=False, missing_kwds=missing_link_kwds, **link_kwds)
+        ax=ax, aspect=aspect, zorder=2, legend=False, **link_kwds)
     
     if link_cbar:
         sm = mpl.cm.ScalarMappable(cmap=link_kwds["cmap"])


### PR DESCRIPTION
## Summary

<!-- Summarize your changes, including any issues resolved by this pull request -->
This PR extends work started in #563 to links. When a partial link attribute is provided, the other links are still shown in black rather than not being shown at all (the desired behavior). This has been fixed here.

## Tests and Documentation

<!-- Describe the tests and documentation added or updated for new features -->

## AI Disclosure

<!-- If you did not use AI tools, mark the checkbox below and skip the rest of this section -->
- [x] No AI tools were used in this contribution

<!-- If you used AI tools, complete the following instead -->
- [ ] I used AI tools in this contribution. <!-- Disclose the AI tools that were used (e.g., GitHub Copilot, ChatGPT) and the use of AI (e.g., generate concept/idea, code generation, code refactoring, documentation generation, code test generation). -->

## Acknowledgement

By contributing to WNTR, I acknowledge that I have reviewed the [software quality assurance guidelines](https://usepa.github.io/WNTR/developers.html) and agree to the following terms and conditions for my contribution:

1. I agree that my contributions are submitted under the Revised BSD License.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
3. If code was generated using AI tools, I have disclosed the use of AI and reviewed all code for quality assurance, correctness, security, and licensing.

- [x] I have read and agree to the above acknowledgement
