### PR TITLE
Fix wheel testing

### DIFF
--- a/wntr/tests/_test_paths.py
+++ b/wntr/tests/_test_paths.py
@@ -1,0 +1,7 @@
+from os.path import abspath, dirname, join
+
+TEST_DIR = dirname(abspath(__file__))
+NETWORKS_FOR_TESTING_DIR = join(TEST_DIR, "networks_for_testing")
+DATA_FOR_TESTING_DIR = join(TEST_DIR, "data_for_testing")
+EXAMPLES_NETWORKS_DIR = join(TEST_DIR, "..", "..", "examples", "networks")
+EXAMPLES_DIR = join(TEST_DIR, "..", "..", "examples")

--- a/wntr/tests/conftest.py
+++ b/wntr/tests/conftest.py
@@ -2,11 +2,13 @@ import atexit
 import os
 import shutil
 import tempfile
-from os.path import abspath, dirname, join
+import warnings
+from os.path import abspath
 
-# Coerce mpl backend to non-interactive
+# Coerce mpl backend to non-interactive and suppress the resulting plt.show() warning
 import matplotlib
 matplotlib.use("Agg")
+warnings.filterwarnings("ignore", message="FigureCanvasAgg is non-interactive")
 
 
 # Manage working directory for testing
@@ -23,10 +25,3 @@ else:
 _original_cwd = os.getcwd()
 os.chdir(_test_cwd)
 atexit.register(os.chdir, _original_cwd)
-
-# Common dirs for testing
-TEST_DIR = dirname(abspath(__file__))
-NETWORKS_FOR_TESTING_DIR = join(TEST_DIR, "networks_for_testing")
-DATA_FOR_TESTING_DIR = join(TEST_DIR, "data_for_testing")
-EXAMPLES_NETWORKS_DIR = join(TEST_DIR, "..", "..", "examples", "networks")
-EXAMPLES_DIR = join(TEST_DIR, "..", "..", "examples")

--- a/wntr/tests/test_demos.py
+++ b/wntr/tests/test_demos.py
@@ -11,7 +11,7 @@ from pandas.testing import assert_frame_equal
 from nbconvert.preprocessors import ExecutePreprocessor
 
 kernel_name = 'python%d' % sys.version_info[0]
-from wntr.tests.conftest import (
+from _test_paths import (
     TEST_DIR as testdir,
     EXAMPLES_DIR as examplesdir,
 )

--- a/wntr/tests/test_epanet_exceptions.py
+++ b/wntr/tests/test_epanet_exceptions.py
@@ -3,7 +3,7 @@ from os.path import join
 
 import wntr.epanet.exceptions
 
-from wntr.tests.conftest import (
+from _test_paths import (
     NETWORKS_FOR_TESTING_DIR as datadir,
 )
 

--- a/wntr/tests/test_epanet_io.py
+++ b/wntr/tests/test_epanet_io.py
@@ -4,7 +4,7 @@ from os.path import join
 
 from numpy.testing._private.utils import assert_string_equal
 
-from wntr.tests.conftest import (
+from _test_paths import (
     NETWORKS_FOR_TESTING_DIR as test_datadir,
     EXAMPLES_NETWORKS_DIR as ex_datadir,
 )

--- a/wntr/tests/test_epanet_msx_io.py
+++ b/wntr/tests/test_epanet_msx_io.py
@@ -8,7 +8,7 @@ import wntr
 import wntr.msx
 import wntr.epanet.msx
 
-from wntr.tests.conftest import (
+from _test_paths import (
     NETWORKS_FOR_TESTING_DIR as test_network_dir,
 )
 inp_filename = join(test_network_dir, "msx_example.inp")

--- a/wntr/tests/test_epanet_msx_sim.py
+++ b/wntr/tests/test_epanet_msx_sim.py
@@ -8,7 +8,7 @@ import wntr
 import wntr.msx
 import wntr.epanet.msx
 
-from wntr.tests.conftest import (
+from _test_paths import (
     NETWORKS_FOR_TESTING_DIR as test_network_dir,
 )
 inp_filename = join(test_network_dir, "msx_example.inp")

--- a/wntr/tests/test_epanet_msx_tooklit.py
+++ b/wntr/tests/test_epanet_msx_tooklit.py
@@ -9,7 +9,7 @@ import wntr.msx
 import wntr.epanet.msx
 import wntr.epanet.msx.toolkit
 
-from wntr.tests.conftest import (
+from _test_paths import (
     NETWORKS_FOR_TESTING_DIR as test_network_dir,
 )
 inp_filename = join(test_network_dir, 'msx_example.inp')

--- a/wntr/tests/test_epanet_toolkit.py
+++ b/wntr/tests/test_epanet_toolkit.py
@@ -9,7 +9,7 @@ if 'darwin' in sys.platform.lower() and 'arm' in platform.platform().lower():
 else:
     skip_v2_tests_on_arm = False
 
-from wntr.tests.conftest import (
+from _test_paths import (
     EXAMPLES_NETWORKS_DIR as datadir,
 )
 

--- a/wntr/tests/test_examples.py
+++ b/wntr/tests/test_examples.py
@@ -7,7 +7,7 @@ from os import listdir
 from os.path import isfile, join
 from subprocess import call
 
-from wntr.tests.conftest import (
+from _test_paths import (
     EXAMPLES_DIR as examplesdir,
 )
 

--- a/wntr/tests/test_gis.py
+++ b/wntr/tests/test_gis.py
@@ -31,7 +31,7 @@ except ModuleNotFoundError:
     rasterio = None
     has_rasterio = False
     
-from wntr.tests.conftest import (
+from _test_paths import (
     TEST_DIR as testdir,
     NETWORKS_FOR_TESTING_DIR as datadir,
     EXAMPLES_NETWORKS_DIR as ex_datadir,

--- a/wntr/tests/test_graphics.py
+++ b/wntr/tests/test_graphics.py
@@ -12,7 +12,7 @@ import pandas as pd
 import numpy as np
 import wntr
 
-from wntr.tests.conftest import (
+from _test_paths import (
     NETWORKS_FOR_TESTING_DIR as test_datadir,
     EXAMPLES_NETWORKS_DIR as ex_datadir,
 )

--- a/wntr/tests/test_library_demand.py
+++ b/wntr/tests/test_library_demand.py
@@ -8,7 +8,7 @@ import matplotlib.pylab as plt
 import wntr
 from wntr.library import DemandPatternLibrary
 
-from wntr.tests.conftest import (
+from _test_paths import (
     EXAMPLES_NETWORKS_DIR as ex_datadir,
 )
 

--- a/wntr/tests/test_library_model.py
+++ b/wntr/tests/test_library_model.py
@@ -5,7 +5,7 @@ from os.path import join
 from wntr.network import WaterNetworkModel
 from wntr.library import ModelLibrary, model_library
 
-from wntr.tests.conftest import (
+from _test_paths import (
     NETWORKS_FOR_TESTING_DIR as test_datadir,
 )
 

--- a/wntr/tests/test_metrics_demand.py
+++ b/wntr/tests/test_metrics_demand.py
@@ -7,7 +7,7 @@ import pandas as pd
 import wntr
 from pandas.testing import assert_frame_equal, assert_series_equal
 
-from wntr.tests.conftest import (
+from _test_paths import (
     EXAMPLES_NETWORKS_DIR as net3dir,
 )
 

--- a/wntr/tests/test_metrics_economic.py
+++ b/wntr/tests/test_metrics_economic.py
@@ -5,7 +5,7 @@ import pandas as pd
 import wntr
 from pandas.testing import assert_frame_equal, assert_series_equal
 
-from wntr.tests.conftest import (
+from _test_paths import (
     NETWORKS_FOR_TESTING_DIR as datadir,
     EXAMPLES_NETWORKS_DIR as netdir,
 )

--- a/wntr/tests/test_metrics_entropy.py
+++ b/wntr/tests/test_metrics_entropy.py
@@ -4,7 +4,7 @@ from os.path import join
 import numpy as np
 import wntr
 
-from wntr.tests.conftest import (
+from _test_paths import (
     NETWORKS_FOR_TESTING_DIR as datadir,
 )
 

--- a/wntr/tests/test_metrics_healthimpacts.py
+++ b/wntr/tests/test_metrics_healthimpacts.py
@@ -9,7 +9,7 @@ if 'darwin' in sys.platform.lower() and 'arm' in platform.platform().lower():
 else:
     skip_v2_tests_on_arm = False
 
-from wntr.tests.conftest import (
+from _test_paths import (
     EXAMPLES_NETWORKS_DIR as netdir,
 )
 

--- a/wntr/tests/test_metrics_population.py
+++ b/wntr/tests/test_metrics_population.py
@@ -5,7 +5,7 @@ import pandas as pd
 import wntr
 from pandas.testing import assert_frame_equal, assert_series_equal
 
-from wntr.tests.conftest import (
+from _test_paths import (
     EXAMPLES_NETWORKS_DIR as net3dir,
 )
 

--- a/wntr/tests/test_metrics_pump_cost.py
+++ b/wntr/tests/test_metrics_pump_cost.py
@@ -3,7 +3,7 @@ from os.path import join
 
 import pandas as pd
 
-from wntr.tests.conftest import (
+from _test_paths import (
     EXAMPLES_NETWORKS_DIR as ex_datadir,
 )
 

--- a/wntr/tests/test_metrics_segments.py
+++ b/wntr/tests/test_metrics_segments.py
@@ -6,7 +6,7 @@ import pandas as pd
 import networkx as nx
 import wntr
 
-from wntr.tests.conftest import (
+from _test_paths import (
     NETWORKS_FOR_TESTING_DIR as test_datadir,
     EXAMPLES_NETWORKS_DIR as ex_datadir,
 )

--- a/wntr/tests/test_metrics_todini.py
+++ b/wntr/tests/test_metrics_todini.py
@@ -4,7 +4,7 @@ from pandas.testing import assert_frame_equal, assert_series_equal
 
 import wntr
 
-from wntr.tests.conftest import (
+from _test_paths import (
     NETWORKS_FOR_TESTING_DIR as datadir,
     EXAMPLES_NETWORKS_DIR as ex_datadir,
 )

--- a/wntr/tests/test_metrics_valve_criticality.py
+++ b/wntr/tests/test_metrics_valve_criticality.py
@@ -5,7 +5,7 @@ import pandas as pd
 import wntr
 from pandas.testing import assert_frame_equal, assert_series_equal
 
-from wntr.tests.conftest import (
+from _test_paths import (
     NETWORKS_FOR_TESTING_DIR as test_datadir,
     EXAMPLES_NETWORKS_DIR as ex_datadir,
 )

--- a/wntr/tests/test_models.py
+++ b/wntr/tests/test_models.py
@@ -7,7 +7,7 @@ import pandas as pd
 import wntr
 from wntr.sim.models.utils import ModelUpdater
 
-from wntr.tests.conftest import (
+from _test_paths import (
     DATA_FOR_TESTING_DIR as test_data_dir,
 )
 

--- a/wntr/tests/test_morph.py
+++ b/wntr/tests/test_morph.py
@@ -7,7 +7,7 @@ import numpy as np
 import pandas as pd
 import wntr
 
-from wntr.tests.conftest import (
+from _test_paths import (
     NETWORKS_FOR_TESTING_DIR as datadir,
     EXAMPLES_NETWORKS_DIR as netdir,
 )

--- a/wntr/tests/test_multiple_simulations.py
+++ b/wntr/tests/test_multiple_simulations.py
@@ -5,7 +5,7 @@ from os.path import join
 
 import pandas as pd
 
-from wntr.tests.conftest import (
+from _test_paths import (
     EXAMPLES_NETWORKS_DIR as ex_datadir,
 )
 

--- a/wntr/tests/test_network.py
+++ b/wntr/tests/test_network.py
@@ -14,7 +14,7 @@ except ModuleNotFoundError:
     gpd = None
     has_geopandas = False
     
-from wntr.tests.conftest import (
+from _test_paths import (
     NETWORKS_FOR_TESTING_DIR as test_network_dir,
     DATA_FOR_TESTING_DIR as test_data_dir,
     EXAMPLES_NETWORKS_DIR as ex_datadir,

--- a/wntr/tests/test_network_controls.py
+++ b/wntr/tests/test_network_controls.py
@@ -7,7 +7,7 @@ import copy
 import wntr
 from wntr.epanet.io import _read_control_line
 
-from wntr.tests.conftest import (
+from _test_paths import (
     NETWORKS_FOR_TESTING_DIR as test_datadir,
 )
 

--- a/wntr/tests/test_network_graph.py
+++ b/wntr/tests/test_network_graph.py
@@ -6,7 +6,7 @@ import networkx as nx
 import numpy as np
 import wntr
 
-from wntr.tests.conftest import (
+from _test_paths import (
     NETWORKS_FOR_TESTING_DIR as datadir,
     EXAMPLES_NETWORKS_DIR as netdir,
 )

--- a/wntr/tests/test_network_layers.py
+++ b/wntr/tests/test_network_layers.py
@@ -5,7 +5,7 @@ import pandas as pd
 import wntr
 from pandas.testing import assert_frame_equal
 
-from wntr.tests.conftest import (
+from _test_paths import (
     NETWORKS_FOR_TESTING_DIR as test_datadir,
     EXAMPLES_NETWORKS_DIR as ex_datadir,
 )

--- a/wntr/tests/test_network_leaks.py
+++ b/wntr/tests/test_network_leaks.py
@@ -2,7 +2,7 @@ import math
 import unittest
 from os.path import join
 
-from wntr.tests.conftest import (
+from _test_paths import (
     NETWORKS_FOR_TESTING_DIR as test_datadir,
 )
 

--- a/wntr/tests/test_network_pump_outage.py
+++ b/wntr/tests/test_network_pump_outage.py
@@ -4,7 +4,7 @@ from os.path import join
 
 from wntr.network.controls import Control, Rule
 
-from wntr.tests.conftest import (
+from _test_paths import (
     EXAMPLES_NETWORKS_DIR as ex_datadir,
 )
 

--- a/wntr/tests/test_network_valves.py
+++ b/wntr/tests/test_network_valves.py
@@ -4,7 +4,7 @@ import wntr
 from os.path import join
 
 
-from wntr.tests.conftest import (
+from _test_paths import (
     NETWORKS_FOR_TESTING_DIR as test_datadir,
 )
 

--- a/wntr/tests/test_sceanrio_earthquake.py
+++ b/wntr/tests/test_sceanrio_earthquake.py
@@ -7,7 +7,7 @@ import pandas as pd
 import wntr
 from pandas.testing import assert_frame_equal, assert_series_equal
 
-from wntr.tests.conftest import (
+from _test_paths import (
     EXAMPLES_NETWORKS_DIR as netdir,
 )
 

--- a/wntr/tests/test_sim_PDD.py
+++ b/wntr/tests/test_sim_PDD.py
@@ -2,7 +2,7 @@ import math
 import unittest
 from os.path import join
 
-from wntr.tests.conftest import (
+from _test_paths import (
     NETWORKS_FOR_TESTING_DIR as test_datadir,
 )
 

--- a/wntr/tests/test_sim_benchmark.py
+++ b/wntr/tests/test_sim_benchmark.py
@@ -25,7 +25,7 @@ from numpy import (
 from scipy.integrate import solve_ivp
 from scipy.optimize import fsolve
 
-from wntr.tests.conftest import (
+from _test_paths import (
     TEST_DIR as testdir,
 )
 

--- a/wntr/tests/test_sim_demand_multiplier.py
+++ b/wntr/tests/test_sim_demand_multiplier.py
@@ -4,7 +4,7 @@ from os.path import join
 
 import wntr
 
-from wntr.tests.conftest import (
+from _test_paths import (
     EXAMPLES_NETWORKS_DIR as ex_datadir,
 )
 

--- a/wntr/tests/test_sim_performance.py
+++ b/wntr/tests/test_sim_performance.py
@@ -10,7 +10,7 @@ import pandas
 
 pandas.set_option("display.max_rows", 10000)
 
-from wntr.tests.conftest import (
+from _test_paths import (
     NETWORKS_FOR_TESTING_DIR as test_datadir,
     EXAMPLES_NETWORKS_DIR as ex_datadir,
 )

--- a/wntr/tests/test_sim_reset_conditions.py
+++ b/wntr/tests/test_sim_reset_conditions.py
@@ -5,7 +5,7 @@ from os.path import join
 import matplotlib.pylab as plt
 import wntr
 
-from wntr.tests.conftest import (
+from _test_paths import (
     EXAMPLES_NETWORKS_DIR as ex_datadir,
 )
 

--- a/wntr/tests/test_sim_results.py
+++ b/wntr/tests/test_sim_results.py
@@ -3,7 +3,7 @@ from os.path import join
 #import matplotlib.pylab as plt
 import wntr
 
-from wntr.tests.conftest import (
+from _test_paths import (
     EXAMPLES_NETWORKS_DIR as datadir,
 )
 

--- a/wntr/tests/test_sim_waterquality.py
+++ b/wntr/tests/test_sim_waterquality.py
@@ -8,7 +8,7 @@ if 'darwin' in sys.platform.lower() and 'arm' in platform.platform().lower():
 else:
     skip_v2_tests_on_arm = False
 
-from wntr.tests.conftest import (
+from _test_paths import (
     EXAMPLES_NETWORKS_DIR as datadir,
 )
 

--- a/wntr/tests/test_times.py
+++ b/wntr/tests/test_times.py
@@ -1,7 +1,7 @@
 import unittest
 from os.path import join
 
-from wntr.tests.conftest import (
+from _test_paths import (
     NETWORKS_FOR_TESTING_DIR as test_datadir,
 )
 


### PR DESCRIPTION
## Summary

<!-- Summarize your changes, including any issues resolved by this pull request -->
Wheel testing was failing because of issues with the filepaths declared in conftest.py.
This PR addresses this issue by making some minor tweaks to the test suite configuration:

- Removed wntr/tests/__init__.py — tests are no longer a subpackage, so they don't get bundled into the wheel
- Moved shared path constants out of conftest.py into a new _test_paths.py utility module. conftest is now purely pytest infrastructure (backend, CWD isolation), while path constants live somewhere that makes their purpose obvious
- Updated all 40 test files to import from _test_paths instead of wntr.tests.conftest. This also fixes the CI wheel-test failure, since bare import _test_paths resolves from the local checkout rather than the installed package

## Tests and Documentation

<!-- Describe the tests and documentation added or updated for new features -->

## AI Disclosure

<!-- If you did not use AI tools, mark the checkbox below and skip the rest of this section -->
- [x] No AI tools were used in this contribution

<!-- If you used AI tools, complete the following instead -->
- [ ] I used AI tools in this contribution. <!-- Disclose the AI tools that were used (e.g., GitHub Copilot, ChatGPT) and the use of AI (e.g., generate concept/idea, code generation, code refactoring, documentation generation, code test generation). -->

## Acknowledgement

By contributing to WNTR, I acknowledge that I have reviewed the [software quality assurance guidelines](https://usepa.github.io/WNTR/developers.html) and agree to the following terms and conditions for my contribution:

1. I agree that my contributions are submitted under the Revised BSD License.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
3. If code was generated using AI tools, I have disclosed the use of AI and reviewed all code for quality assurance, correctness, security, and licensing.

- [x] I have read and agree to the above acknowledgement
